### PR TITLE
Feature/oc 392/objecten koppelen

### DIFF
--- a/pwa/src/apiService/resources/object.ts
+++ b/pwa/src/apiService/resources/object.ts
@@ -26,6 +26,12 @@ export default class Sources {
     return data;
   };
 
+  public getAllFromList = async (list: string): Promise<any> => {
+    const { data } = await Send(this._instance, "GET", list);
+
+    return data;
+  };
+
   public getSchema = async (id: string): Promise<any> => {
     const instance = this._instance;
 

--- a/pwa/src/hooks/object.ts
+++ b/pwa/src/hooks/object.ts
@@ -33,6 +33,14 @@ export const useObject = (queryClient: QueryClient) => {
       enabled: !!entityId,
     });
 
+  const getAllFromList = (list: string) =>
+    useQuery<any[], Error>(["objects", list], () => API.Object.getAllFromList(list), {
+      onError: (error) => {
+        throw new Error(error.message);
+      },
+      enabled: !!list,
+    });
+
   const getSchema = (objectId: string) =>
     useQuery<any[], Error>(["object_schema", objectId], () => API.Object.getSchema(objectId), {
       onError: (error) => {
@@ -71,5 +79,5 @@ export const useObject = (queryClient: QueryClient) => {
       },
     });
 
-  return { getAll, getOne, getAllFromEntity, getSchema, remove, createOrEdit };
+  return { getAll, getOne, getAllFromEntity, getAllFromList, getSchema, remove, createOrEdit };
 };

--- a/pwa/src/templates/templateParts/propertyForm/CreatePropertyFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/propertyForm/CreatePropertyFormTemplate.tsx
@@ -15,6 +15,8 @@ import { navigate } from "gatsby";
 import { ArrowLeftIcon } from "@gemeente-denhaag/icons";
 import { SelectCreate } from "@conduction/components/lib/components/formFields/select/select";
 import { CreateKeyValue } from "@conduction/components/lib/components/formFields";
+import { useSchema } from "../../../hooks/schema";
+import Skeleton from "react-loading-skeleton";
 
 interface CreatePropertyFormTemplateProps {
   schemaId: string;
@@ -32,7 +34,9 @@ export const CreatePropertyFormTemplate: React.FC<CreatePropertyFormTemplateProp
   const queryClient = useQueryClient();
   const _useAttribute = useAttribute(queryClient);
   const createOrEditAttribute = _useAttribute.createOrEdit(schemaId, propertyId);
-  // const getAttributes = _useAttribute.getAll();
+
+  const _useSchema = useSchema(queryClient);
+  const getSchemas = _useSchema.getAll();
 
   const typeSelectOptions = [
     { label: "String", value: "string" },
@@ -95,6 +99,7 @@ export const CreatePropertyFormTemplate: React.FC<CreatePropertyFormTemplateProp
       return setFormError(t("The minProperties is bigger than the maxProperties"));
     if (data.minDate > data.maxDate) return setFormError(t("The minDate is bigger than the maxDate"));
     if (data.minFileSize > data.maxFileSize) return setFormError(t("The minFileSize is bigger than the maxFileSize"));
+
     const payload = {
       ...data,
       type: data.type && data.type.value,
@@ -102,7 +107,9 @@ export const CreatePropertyFormTemplate: React.FC<CreatePropertyFormTemplateProp
       function: data.function && data.function.value,
       entity: `/admin/entities/${schemaId}`,
       fileTypes: data.fileTypes?.map((fileType: any) => fileType.value),
+      object: data.object.value,
     };
+
     createOrEditAttribute.mutate({ payload, id: propertyId });
   };
 
@@ -214,6 +221,27 @@ export const CreatePropertyFormTemplate: React.FC<CreatePropertyFormTemplateProp
                       />
                     </FormFieldInput>
                   </FormField>
+
+                  {selectedType === "object" && getSchemas.isLoading && <Skeleton height="50px" />}
+
+                  {selectedType === "object" && getSchemas.isSuccess && (
+                    <FormField>
+                      <FormFieldInput>
+                        <FormFieldLabel>{t("Schema")}</FormFieldLabel>
+                        {/* @ts-ignore */}
+                        <SelectSingle
+                          {...{ register, errors, control }}
+                          name="object"
+                          options={getSchemas.data.map((schema: any) => ({
+                            label: schema.name,
+                            value: `/admin/entities/${schema.id}`,
+                          }))}
+                          disabled={loading}
+                          validation={{ required: true }}
+                        />
+                      </FormFieldInput>
+                    </FormField>
+                  )}
                 </div>
               </div>
             </TabPanel>
@@ -404,22 +432,6 @@ export const CreatePropertyFormTemplate: React.FC<CreatePropertyFormTemplateProp
                     )}
                   </div>
                 </div>
-
-                {/* <FormField>
-                    <FormFieldInput>
-                      <FormFieldLabel>{t("inversedBy")}</FormFieldLabel>
-                      {getAttributes.isLoading && <Skeleton height="50px" />}
-                      {getAttributes.isSuccess && (
-                        //@ts-ignore
-                        <SelectSingle
-                          {...{ register, errors, control }}
-                          name="inversedBy"
-                          options={getAttributes.data.map((schema: any) => ({ label: schema.name, value: schema.id }))}
-                          disabled={loading}
-                        />
-                      )}
-                    </FormFieldInput>
-                  </FormField> */}
 
                 <div className={styles.gridContainer}>
                   <div className={styles.grid}>

--- a/pwa/src/templates/templateParts/propertyForm/CreatePropertyFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/propertyForm/CreatePropertyFormTemplate.tsx
@@ -107,7 +107,7 @@ export const CreatePropertyFormTemplate: React.FC<CreatePropertyFormTemplateProp
       function: data.function && data.function.value,
       entity: `/admin/entities/${schemaId}`,
       fileTypes: data.fileTypes?.map((fileType: any) => fileType.value),
-      object: data.object.value,
+      object: data?.object?.value,
     };
 
     createOrEditAttribute.mutate({ payload, id: propertyId });

--- a/pwa/src/templates/templateParts/propertyForm/EditPropertyFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/propertyForm/EditPropertyFormTemplate.tsx
@@ -14,6 +14,8 @@ import clsx from "clsx";
 import { useAttribute } from "../../../hooks/attribute";
 import { CreateKeyValue } from "@conduction/components/lib/components/formFields";
 import { SelectCreate } from "@conduction/components/lib/components/formFields/select/select";
+import { useSchema } from "../../../hooks/schema";
+import Skeleton from "react-loading-skeleton";
 
 interface EditPropertyFormTemplateProps {
   property: any;
@@ -47,7 +49,9 @@ export const EditPropertyFormTemplate: React.FC<EditPropertyFormTemplateProps> =
   const _useAttribute = useAttribute(queryClient);
   const createOrEditProperty = _useAttribute.createOrEdit(schemaId, propertyId);
   const deleteProperty = _useAttribute.remove(schemaId);
-  // const getAttributes = _useAttribute.getAll();
+
+  const _useSchema = useSchema(queryClient);
+  const getSchemas = _useSchema.getAll();
 
   const typeSelectOptions = [
     { label: "String", value: "string" },
@@ -97,6 +101,16 @@ export const EditPropertyFormTemplate: React.FC<EditPropertyFormTemplateProps> =
   const watchType = watch("type");
 
   React.useEffect(() => {
+    if (!getSchemas.isSuccess) return;
+
+    setValue("object", () => {
+      const schema = getSchemas.data?.find((schema) => schema.id === property.object.id);
+
+      return { label: schema.name, value: `/admin/entities/${schema.id}` };
+    });
+  }, [getSchemas.isSuccess]);
+
+  React.useEffect(() => {
     if (!watchType) return;
 
     const selectedType = typeSelectOptions.find((typeOption) => typeOption.value === watchType.value);
@@ -118,6 +132,7 @@ export const EditPropertyFormTemplate: React.FC<EditPropertyFormTemplateProps> =
       format: data.format && data.format.value,
       function: data.function && data.function.value,
       fileTypes: data.fileTypes?.map((fileType: any) => fileType.value),
+      object: data.object.value,
 
       // inversedBy: data.inversedBy && data.inversedBy,
       // inversedBy: data.inversedBy && `App\\Entity\\${data.inversedBy.label}`,
@@ -384,6 +399,27 @@ export const EditPropertyFormTemplate: React.FC<EditPropertyFormTemplateProps> =
                       />
                     </FormFieldInput>
                   </FormField>
+
+                  {selectedType === "object" && getSchemas.isLoading && <Skeleton height="50px" />}
+
+                  {selectedType === "object" && getSchemas.isSuccess && (
+                    <FormField>
+                      <FormFieldInput>
+                        <FormFieldLabel>{t("Schema")}</FormFieldLabel>
+                        {/* @ts-ignore */}
+                        <SelectSingle
+                          {...{ register, errors, control }}
+                          name="object"
+                          options={getSchemas.data.map((schema: any) => ({
+                            label: schema.name,
+                            value: `/admin/entities/${schema.id}`,
+                          }))}
+                          disabled={loading}
+                          validation={{ required: true }}
+                        />
+                      </FormFieldInput>
+                    </FormField>
+                  )}
                 </div>
               </div>
             </TabPanel>

--- a/pwa/src/templates/templateParts/propertyForm/EditPropertyFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/propertyForm/EditPropertyFormTemplate.tsx
@@ -132,7 +132,7 @@ export const EditPropertyFormTemplate: React.FC<EditPropertyFormTemplateProps> =
       format: data.format && data.format.value,
       function: data.function && data.function.value,
       fileTypes: data.fileTypes?.map((fileType: any) => fileType.value),
-      object: data.object.value,
+      object: data?.object?.value,
 
       // inversedBy: data.inversedBy && data.inversedBy,
       // inversedBy: data.inversedBy && `App\\Entity\\${data.inversedBy.label}`,

--- a/pwa/src/templates/templateParts/schemaForm/SchemaFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/schemaForm/SchemaFormTemplate.tsx
@@ -356,14 +356,26 @@ const SchemaTypeObject: React.FC<FormFieldGroupProps & ReactHookFormProps> = ({
 }) => {
   const queryClient = new QueryClient();
   const _useObject = useObject(queryClient);
-  const getAllFromList = _useObject.getAllFromList(schema.properties[name]._list);
+  const getAllFromList = _useObject.getAllFromList(schema?.properties[name]?._list);
 
   if (getAllFromList.isLoading) return <Skeleton height="50px" />;
   if (getAllFromList.isError) return <>Something went wrong...</>;
 
+  if (multiple) {
+    return (
+      <SelectMultiple
+        // defaultValue={{}} <== TODO
+        options={getAllFromList.data?.map((object) => ({ label: object.name, value: object.id })) ?? []}
+        disabled={disabled || readOnly}
+        {...{ register, errors, placeholder, name, control }}
+        validation={{ required }}
+      />
+    );
+  }
+
   return (
     <SelectSingle
-      defaultValue={{}}
+      // defaultValue={{}} <== TODO
       options={getAllFromList.data?.map((object) => ({ label: object.name, value: object.id })) ?? []}
       disabled={disabled || readOnly}
       {...{ register, errors, placeholder, name, control }}


### PR DESCRIPTION
Adds logic to:

- Link schema properties of type "object" to other schemas;
- Generated "object" form input fields get a dropdown of all objects, based on linked schema.

Note: the gateway does not yet fill the `value` property in the json-schema, and therefore, the edit cannot pre-fill the selected object.