### PR TITLE
CLEANUP filterConsole, removes shape-rendering error

### DIFF
--- a/pwa/src/layout/Head.tsx
+++ b/pwa/src/layout/Head.tsx
@@ -2,12 +2,15 @@ import * as React from "react";
 import _ from "lodash";
 import "../styling/index.css";
 import { Helmet } from "react-helmet";
+import { filterConsole } from "../services/filterConsole";
 
 interface HeadProps {
   crumbs: any[];
 }
 
 export const Head: React.FC<HeadProps> = ({ crumbs }) => {
+  filterConsole();
+
   const title = crumbs && _.capitalize(_.last(crumbs).crumbLabel);
 
   return (

--- a/pwa/src/services/filterConsole.ts
+++ b/pwa/src/services/filterConsole.ts
@@ -1,0 +1,12 @@
+/**
+ * Unfortunately, some packages send some errors or warnings that they do not fix and are unimportant.
+ * To keep a clean development environment (not cluttered with redundant error messages in our console), this service exists.
+ *
+ * IMPORTANT NOTE: we should ALWAYS peer-review any and all additions to this file.
+ */
+
+export const filterConsole = () => {
+  if (!console.error.toString().includes("shape-rendering")) {
+    console.error();
+  }
+};


### PR DESCRIPTION
Removes the (redundant) `shape-rendering` error from the console 🥳 