### PR TITLE
Feature/oc 439/form resubmission on error

### DIFF
--- a/pwa/src/components/toggleButton/ToggleButton.tsx
+++ b/pwa/src/components/toggleButton/ToggleButton.tsx
@@ -8,6 +8,7 @@ interface ToggleButtonProps {
   defaultState?: boolean;
   onChange?: () => any;
   layoutClassName?: any;
+  disabled?: boolean;
 }
 
 const ToggleButton: React.FC<ToggleButtonProps> = ({
@@ -16,6 +17,7 @@ const ToggleButton: React.FC<ToggleButtonProps> = ({
   defaultState,
   onChange,
   layoutClassName,
+  disabled,
 }) => {
   const [isEnabled, setIsEnabled] = React.useState<boolean>(defaultState ?? false);
 
@@ -31,7 +33,7 @@ const ToggleButton: React.FC<ToggleButtonProps> = ({
     <div className={clsx(styles.container, [layoutClassName && layoutClassName])}>
       {startLabel}
       <div className={styles.switchContainer}>
-        <input id={uuid} type="checkbox" checked={isEnabled} onChange={handleChange} />
+        <input id={uuid} type="checkbox" checked={isEnabled} onChange={handleChange} {...{ disabled }} />
         <label htmlFor={uuid}></label>
       </div>
       {endLabel}

--- a/pwa/src/hooks/object.ts
+++ b/pwa/src/hooks/object.ts
@@ -3,7 +3,6 @@ import { QueryClient, useMutation, useQuery, useQueryClient } from "react-query"
 import APIService from "../apiService/apiService";
 import APIContext from "../apiService/apiContext";
 import { addItem, deleteItem, updateItem } from "../services/mutateQueries";
-import { navigate } from "gatsby";
 import { IFilters } from "../context/filters";
 
 export const useObject = (queryClient: QueryClient) => {

--- a/pwa/src/templates/gatewayDetailTemplate/GatewayDetailTemplate.tsx
+++ b/pwa/src/templates/gatewayDetailTemplate/GatewayDetailTemplate.tsx
@@ -14,6 +14,7 @@ import { VerticalMenu } from "../templateParts/verticalMenu/VerticalMenu";
 
 export const GatewayDetailTemplate: React.FC = () => {
   const { t } = useTranslation();
+  const [loading, setLoading] = React.useState<boolean>(false);
   const [currentRequire, setCurrentRequire] = React.useState<string>("");
   const [showmoreVersions, setShowmoreVersions] = React.useState<boolean>(false);
 
@@ -36,6 +37,10 @@ export const GatewayDetailTemplate: React.FC = () => {
         onClick: () => setCurrentRequire(data.version),
       }))
     : [];
+
+  React.useEffect(() => {
+    setLoading(upgradePlugin.isLoading);
+  }, [upgradePlugin.isLoading]);
 
   React.useEffect(() => {
     if (!getPlugins.data) return;
@@ -73,7 +78,7 @@ export const GatewayDetailTemplate: React.FC = () => {
             </div>
 
             <div className={styles.buttons}>
-              <Button onClick={handleUpgradePlugin} className={styles.buttonIcon} type="submit">
+              <Button onClick={handleUpgradePlugin} className={styles.buttonIcon} type="submit" disabled={loading}>
                 <FontAwesomeIcon icon={faArrowsRotate} />
                 {t(getPlugins.data?.update ? "Upgrade to" : "Upgrade")}{" "}
                 {getPlugins.data?.update && getPlugins.data.update}

--- a/pwa/src/templates/pluginsDetailTemplate/PluginsDetailTemplate.tsx
+++ b/pwa/src/templates/pluginsDetailTemplate/PluginsDetailTemplate.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as styles from "./PluginsDetailTemplate.module.css";
 import { useTranslation } from "react-i18next";
 import { Container, Tag, ToolTip } from "@conduction/components";
-import { Button, Divider, Heading1, Heading3, Heading4, Link, Paragraph } from "@gemeente-denhaag/components-react";
+import { Button, Divider, Heading1, Heading3, Paragraph } from "@gemeente-denhaag/components-react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faArrowsRotate,
@@ -21,7 +21,6 @@ import { usePlugin } from "../../hooks/plugin";
 import Skeleton from "react-loading-skeleton";
 import { ExternalLinkIcon } from "@gemeente-denhaag/icons";
 import { GitHubLogo } from "../../assets/svgs/GitHub";
-import TableWrapper from "../../components/tableWrapper/TableWrapper";
 import { VerticalMenu } from "../templateParts/verticalMenu/VerticalMenu";
 
 interface PluginsDetailPageProps {
@@ -30,6 +29,7 @@ interface PluginsDetailPageProps {
 
 export const PluginsDetailTemplate: React.FC<PluginsDetailPageProps> = ({ pluginName }) => {
   const { t } = useTranslation();
+  const [loading, setLoading] = React.useState<boolean>(false);
   const [currentRequire, setCurrentRequire] = React.useState<string>("");
   const [showmoreVersions, setShowmoreVersions] = React.useState<boolean>(false);
 
@@ -83,6 +83,10 @@ export const PluginsDetailTemplate: React.FC<PluginsDetailPageProps> = ({ plugin
       : [];
 
   React.useEffect(() => {
+    setLoading(installPlugin.isLoading || upgradePlugin.isLoading || deletePlugin.isLoading);
+  }, [installPlugin.isLoading, upgradePlugin.isLoading, deletePlugin.isLoading]);
+
+  React.useEffect(() => {
     if (!getPlugin.data) return;
 
     const versionExists: boolean = getPlugin.data.version
@@ -112,13 +116,22 @@ export const PluginsDetailTemplate: React.FC<PluginsDetailPageProps> = ({ plugin
               {installed && (
                 <div className={styles.buttons}>
                   {!!getPlugin.data.update && (
-                    <Button onClick={handleUpgradePlugin} className={styles.buttonIcon} type="submit">
+                    <Button
+                      disabled={loading}
+                      onClick={handleUpgradePlugin}
+                      className={styles.buttonIcon}
+                      type="submit"
+                    >
                       <FontAwesomeIcon icon={faArrowsRotate} />
                       {t("Upgrade to")} {getPlugin.data.update}
                     </Button>
                   )}
 
-                  <Button onClick={handleDeletePlugin} className={clsx(styles.buttonIcon, styles.deleteButton)}>
+                  <Button
+                    disabled={loading}
+                    onClick={handleDeletePlugin}
+                    className={clsx(styles.buttonIcon, styles.deleteButton)}
+                  >
                     <FontAwesomeIcon icon={faTrash} />
                     {t("Remove")}
                   </Button>
@@ -126,7 +139,7 @@ export const PluginsDetailTemplate: React.FC<PluginsDetailPageProps> = ({ plugin
               )}
               {!installed && (
                 <div className={styles.buttons}>
-                  <Button onClick={handleInstallPlugin} className={styles.buttonIcon}>
+                  <Button disabled={loading} onClick={handleInstallPlugin} className={styles.buttonIcon}>
                     <FontAwesomeIcon icon={faDownload} />
                     {t("Install")}
                   </Button>

--- a/pwa/src/templates/templateParts/actionsForm/CreateActionFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/actionsForm/CreateActionFormTemplate.tsx
@@ -208,7 +208,7 @@ export const CreateActionFormTemplate: React.FC = () => {
                   <FormField>
                     <FormFieldInput>
                       <FormFieldLabel>{t("is Enabeld")}</FormFieldLabel>
-                      <InputCheckbox {...{ register, errors }} label="on" name="isEnabled" />
+                      <InputCheckbox {...{ register, errors }} disabled={loading} label="on" name="isEnabled" />
                     </FormFieldInput>
                   </FormField>
 

--- a/pwa/src/templates/templateParts/actionsForm/CreateActionFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/actionsForm/CreateActionFormTemplate.tsx
@@ -45,6 +45,10 @@ export const CreateActionFormTemplate: React.FC = () => {
   const watchClass = watch("class");
 
   React.useEffect(() => {
+    setLoading(createOrEditAction.isLoading);
+  }, [createOrEditAction.isLoading]);
+
+  React.useEffect(() => {
     if (!watchClass || !getAllHandlers.data) return;
 
     const selectedHandler = getAllHandlers.data.find((handler) => handler.class === watchClass.value);
@@ -224,12 +228,14 @@ export const CreateActionFormTemplate: React.FC = () => {
                   <FormField>
                     <FormFieldInput>
                       <FormFieldLabel>{t("Conditions")}</FormFieldLabel>
+
                       <Textarea
                         {...{ register, errors }}
                         name="conditions"
                         disabled={loading}
                         validation={{ validate: validateStringAsJSON }}
                       />
+
                       {errors["conditions"] && <ErrorMessage message={errors["conditions"].message} />}
                     </FormFieldInput>
                   </FormField>

--- a/pwa/src/templates/templateParts/actionsForm/EditActionFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/actionsForm/EditActionFormTemplate.tsx
@@ -266,21 +266,21 @@ export const EditActionFormTemplate: React.FC<EditActionFormTemplateProps> = ({ 
                   <FormField>
                     <FormFieldInput>
                       <FormFieldLabel>{t("async")}</FormFieldLabel>
-                      <InputCheckbox {...{ register, errors }} label="on" name="async" />
+                      <InputCheckbox {...{ register, errors }} disabled={loading} label="on" name="async" />
                     </FormFieldInput>
                   </FormField>
 
                   <FormField>
                     <FormFieldInput>
                       <FormFieldLabel>{t("is Enabeld")}</FormFieldLabel>
-                      <InputCheckbox {...{ register, errors }} label="true" name="isEnabled" />
+                      <InputCheckbox {...{ register, errors }} disabled={loading} label="true" name="isEnabled" />
                     </FormFieldInput>
                   </FormField>
 
                   <FormField>
                     <FormFieldInput>
                       <FormFieldLabel>{t("IsLockable")}</FormFieldLabel>
-                      <InputCheckbox {...{ register, errors }} label="on" name="isLockable" />
+                      <InputCheckbox {...{ register, errors }} disabled={loading} label="on" name="isLockable" />
                     </FormFieldInput>
                   </FormField>
                 </div>

--- a/pwa/src/templates/templateParts/actionsForm/EditActionFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/actionsForm/EditActionFormTemplate.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as styles from "./ActionFormTemplate.module.css";
-import { set, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import FormField, { FormFieldInput, FormFieldLabel } from "@gemeente-denhaag/form-field";
 import { Button, Divider, Heading1, Tab, TabContext, TabPanel, Tabs } from "@gemeente-denhaag/components-react";
 import { useTranslation } from "react-i18next";
@@ -67,7 +67,7 @@ export const EditActionFormTemplate: React.FC<EditActionFormTemplateProps> = ({ 
       configuration: {},
     };
 
-    for (const [key, _] of Object.entries(actionHandlerSchema.properties)) {
+    for (const [key, _] of Object.entries(actionHandlerSchema?.properties)) {
       payload.configuration[key] = data[key];
 
       if (actionHandlerSchema.properties[key].type === "object") {
@@ -124,6 +124,10 @@ export const EditActionFormTemplate: React.FC<EditActionFormTemplateProps> = ({ 
       }
     }
   };
+
+  React.useEffect(() => {
+    setLoading(createOrEditAction.isLoading);
+  }, [createOrEditAction.isLoading]);
 
   React.useEffect(() => {
     if (!getCronjobs.data) return;

--- a/pwa/src/templates/templateParts/collectionsForm/CreateCollectionFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/collectionsForm/CreateCollectionFormTemplate.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
 import * as styles from "./CollectionFormTemplate.module.css";
 import { useForm } from "react-hook-form";
-import APIContext from "../../../apiService/apiContext";
 import FormField, { FormFieldInput, FormFieldLabel } from "@gemeente-denhaag/form-field";
-import { Alert, Button, Heading1 } from "@gemeente-denhaag/components-react";
+import { Button, Heading1 } from "@gemeente-denhaag/components-react";
 import { useTranslation } from "react-i18next";
-import APIService from "../../../apiService/apiService";
 import { InputText } from "@conduction/components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFloppyDisk } from "@fortawesome/free-solid-svg-icons";
@@ -18,9 +16,7 @@ interface CreateCollectionFormTemplateProps {
 
 export const CreateCollectionFormTemplate: React.FC<CreateCollectionFormTemplateProps> = ({ collectionId }) => {
   const { t } = useTranslation();
-  const API: APIService | null = React.useContext(APIContext);
   const [loading, setLoading] = React.useState<boolean>(true);
-  const [formError, setFormError] = React.useState<string>("");
 
   const queryClient = useQueryClient();
   const _useCollection = useCollection(queryClient);
@@ -36,6 +32,10 @@ export const CreateCollectionFormTemplate: React.FC<CreateCollectionFormTemplate
     createOrEditCollection.mutate({ payload: data, id: collectionId });
   };
 
+  React.useEffect(() => {
+    setLoading(createOrEditCollection.isLoading);
+  }, [createOrEditCollection.isLoading]);
+
   return (
     <div className={styles.container}>
       <form onSubmit={handleSubmit(onSubmit)}>
@@ -49,7 +49,7 @@ export const CreateCollectionFormTemplate: React.FC<CreateCollectionFormTemplate
             </Button>
           </div>
         </section>
-        {formError && <Alert text={formError} title={t("Oops, something went wrong")} variant="error" />}
+
         <div className={styles.gridContainer}>
           <div className={styles.grid}>
             <FormField>

--- a/pwa/src/templates/templateParts/collectionsForm/EditCollectionFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/collectionsForm/EditCollectionFormTemplate.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
 import * as styles from "./CollectionFormTemplate.module.css";
 import { useForm } from "react-hook-form";
-import APIContext from "../../../apiService/apiContext";
 import FormField, { FormFieldInput, FormFieldLabel } from "@gemeente-denhaag/form-field";
-import { Alert, Button, Heading1 } from "@gemeente-denhaag/components-react";
+import { Button, Heading1 } from "@gemeente-denhaag/components-react";
 import { useTranslation } from "react-i18next";
-import APIService from "../../../apiService/apiService";
 import { InputText } from "@conduction/components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFloppyDisk, faMinus, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
@@ -23,9 +21,7 @@ export const EditCollectionFormTemplate: React.FC<EditCollectionFormTemplateProp
   const { t } = useTranslation();
   const { addOrRemoveDashboardCard, getDashboardCard } = useDashboardCard();
 
-  const API: APIService | null = React.useContext(APIContext);
   const [loading, setLoading] = React.useState<boolean>(false);
-  const [formError, setFormError] = React.useState<string>("");
 
   const queryClient = useQueryClient();
   const _useCollection = useCollection(queryClient);
@@ -46,8 +42,10 @@ export const EditCollectionFormTemplate: React.FC<EditCollectionFormTemplateProp
     queryClient.setQueryData(["collections", collectionId], data);
   };
 
-  const handleDelete = (id: string): void => {
-    deleteCollection.mutateAsync({ id: id });
+  const handleDelete = (): void => {
+    const confirmDeletion = confirm("Are you sure you want to delete this collection?");
+
+    confirmDeletion && deleteCollection.mutateAsync({ id: collectionId });
   };
 
   const addOrRemoveFromDashboard = () => {
@@ -58,6 +56,10 @@ export const EditCollectionFormTemplate: React.FC<EditCollectionFormTemplateProp
     const basicFields: string[] = ["name"];
     basicFields.forEach((field) => setValue(field, collection[field]));
   };
+
+  React.useEffect(() => {
+    setLoading(createOrEditCollection.isLoading || deleteCollection.isLoading);
+  }, [createOrEditCollection.isLoading, deleteCollection.isLoading]);
 
   React.useEffect(() => {
     handleSetFormValues(collection);
@@ -75,18 +77,18 @@ export const EditCollectionFormTemplate: React.FC<EditCollectionFormTemplateProp
               {t("Save")}
             </Button>
 
-            <Button className={styles.buttonIcon} onClick={addOrRemoveFromDashboard}>
+            <Button className={styles.buttonIcon} onClick={addOrRemoveFromDashboard} disabled={loading}>
               <FontAwesomeIcon icon={dashboardCard ? faMinus : faPlus} />
               {dashboardCard ? t("Remove from dashboard") : t("Add to dashboard")}
             </Button>
 
-            <Button className={clsx(styles.buttonIcon, styles.deleteButton)}>
+            <Button onClick={handleDelete} className={clsx(styles.buttonIcon, styles.deleteButton)} disabled={loading}>
               <FontAwesomeIcon icon={faTrash} />
               {t("Delete")}
             </Button>
           </div>
         </section>
-        {formError && <Alert text={formError} title={t("Oops, something went wrong")} variant="error" />}
+
         <div className={styles.container}>
           <div className={styles.grid}>
             <FormField>

--- a/pwa/src/templates/templateParts/cronjobsForm/CreateCronjobsFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/cronjobsForm/CreateCronjobsFormTemplate.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
 import * as styles from "./CronjobsFormTemplate.module.css";
 import { useForm } from "react-hook-form";
-import APIContext from "../../../apiService/apiContext";
 import FormField, { FormFieldInput, FormFieldLabel } from "@gemeente-denhaag/form-field";
-import { Alert, Button, Heading1 } from "@gemeente-denhaag/components-react";
+import { Button, Heading1 } from "@gemeente-denhaag/components-react";
 import { useTranslation } from "react-i18next";
-import APIService from "../../../apiService/apiService";
 import { InputCheckbox, InputText, Textarea } from "@conduction/components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFloppyDisk } from "@fortawesome/free-solid-svg-icons";
@@ -23,9 +21,7 @@ interface CreateCronjobFormTemplateProps {
 
 export const CreateCronjobFormTemplate: React.FC<CreateCronjobFormTemplateProps> = ({ cronjobId }) => {
   const { t } = useTranslation();
-  const API: APIService | null = React.useContext(APIContext);
   const [loading, setLoading] = React.useState<boolean>(false);
-  const [formError, setFormError] = React.useState<string>("");
   const [listensAndThrows, setListensAndThrows] = React.useState<any[]>([]);
 
   const queryClient = useQueryClient();
@@ -38,6 +34,10 @@ export const CreateCronjobFormTemplate: React.FC<CreateCronjobFormTemplateProps>
     control,
     formState: { errors },
   } = useForm();
+
+  React.useEffect(() => {
+    setLoading(createOrEditCronjob.isLoading);
+  }, [createOrEditCronjob.isLoading]);
 
   React.useEffect(() => {
     setListensAndThrows([...predefinedSubscriberEvents]);
@@ -65,7 +65,6 @@ export const CreateCronjobFormTemplate: React.FC<CreateCronjobFormTemplateProps>
             </Button>
           </div>
         </section>
-        {formError && <Alert text={formError} title={t("Oops, something went wrong")} variant="error" />}
         <div className={styles.gridContainer}>
           <div className={styles.grid}>
             <FormField>

--- a/pwa/src/templates/templateParts/cronjobsForm/CreateCronjobsFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/cronjobsForm/CreateCronjobsFormTemplate.tsx
@@ -126,7 +126,7 @@ export const CreateCronjobFormTemplate: React.FC<CreateCronjobFormTemplateProps>
             <FormField>
               <FormFieldInput>
                 <FormFieldLabel>{t("is Enabeld")}</FormFieldLabel>
-                <InputCheckbox {...{ register, errors }} label="on" name="isEnabled" />
+                <InputCheckbox disabled={loading} {...{ register, errors }} label="on" name="isEnabled" />
               </FormFieldInput>
             </FormField>
           </div>

--- a/pwa/src/templates/templateParts/cronjobsForm/EditCronjobFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/cronjobsForm/EditCronjobFormTemplate.tsx
@@ -170,7 +170,7 @@ export const EditCronjobFormTemplate: React.FC<EditCronjobFormTemplateProps> = (
             <FormField>
               <FormFieldInput>
                 <FormFieldLabel>{t("is Enabeld")}</FormFieldLabel>
-                <InputCheckbox {...{ register, errors }} label="true" name="isEnabled" />
+                <InputCheckbox {...{ register, errors }} label="true" name="isEnabled" disabled={loading} />
               </FormFieldInput>
             </FormField>
           </div>

--- a/pwa/src/templates/templateParts/cronjobsForm/EditCronjobFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/cronjobsForm/EditCronjobFormTemplate.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
 import * as styles from "./CronjobsFormTemplate.module.css";
 import { useForm } from "react-hook-form";
-import APIContext from "../../../apiService/apiContext";
 import FormField, { FormFieldInput, FormFieldLabel } from "@gemeente-denhaag/form-field";
-import { Alert, Button, Heading1 } from "@gemeente-denhaag/components-react";
+import { Button, Heading1 } from "@gemeente-denhaag/components-react";
 import { useTranslation } from "react-i18next";
-import APIService from "../../../apiService/apiService";
 import { InputCheckbox, InputText, Textarea } from "@conduction/components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFloppyDisk, faMinus, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
@@ -28,9 +26,7 @@ export const EditCronjobFormTemplate: React.FC<EditCronjobFormTemplateProps> = (
   const { t } = useTranslation();
   const { addOrRemoveDashboardCard, getDashboardCard } = useDashboardCard();
 
-  const API: APIService | null = React.useContext(APIContext);
   const [loading, setLoading] = React.useState<boolean>(false);
-  const [formError, setFormError] = React.useState<string>("");
   const [listensAndThrows, setListensAndThrows] = React.useState<any[]>([]);
 
   const queryClient = useQueryClient();
@@ -72,9 +68,13 @@ export const EditCronjobFormTemplate: React.FC<EditCronjobFormTemplateProps> = (
 
     setValue(
       "throws",
-      cronjob["throws"].map((_throw: any) => ({ label: _throw, value: _throw })),
+      cronjob["throws"]?.map((_throw: any) => ({ label: _throw, value: _throw })),
     );
   };
+
+  React.useEffect(() => {
+    setLoading(createOrEditCronjob.isLoading);
+  }, [createOrEditCronjob.isLoading]);
 
   React.useEffect(() => {
     setListensAndThrows([...predefinedSubscriberEvents]);
@@ -96,18 +96,18 @@ export const EditCronjobFormTemplate: React.FC<EditCronjobFormTemplateProps> = (
               {t("Save")}
             </Button>
 
-            <Button className={styles.buttonIcon} onClick={addOrRemoveFromDashboard}>
+            <Button disabled={loading} className={styles.buttonIcon} onClick={addOrRemoveFromDashboard}>
               <FontAwesomeIcon icon={dashboardCard ? faMinus : faPlus} />
               {dashboardCard ? t("Remove from dashboard") : t("Add to dashboard")}
             </Button>
 
-            <Button className={clsx(styles.buttonIcon, styles.deleteButton)} onClick={handleDelete}>
+            <Button disabled={loading} className={clsx(styles.buttonIcon, styles.deleteButton)} onClick={handleDelete}>
               <FontAwesomeIcon icon={faTrash} />
               {t("Delete")}
             </Button>
           </div>
         </section>
-        {formError && <Alert text={formError} title={t("Oops, something went wrong")} variant="error" />}
+
         <div className={styles.gridContainer}>
           <div className={styles.grid}>
             <FormField>

--- a/pwa/src/templates/templateParts/endpointsForm/CreateEndpointsFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/endpointsForm/CreateEndpointsFormTemplate.tsx
@@ -120,18 +120,24 @@ export const CreateEndpointFormTemplate: React.FC<CreateEndpointFormTemplateProp
             <FormFieldGroup>
               <FormFieldGroupLabel>Methods</FormFieldGroupLabel>
               <FormFieldInput className={styles.grid}>
-                <FormControlLabel input={<Checkbox name="checkbox" onChange={() => addToArray("GET")} />} label="GET" />
                 <FormControlLabel
-                  input={<Checkbox name="checkbox" onChange={() => addToArray("POST")} />}
+                  input={<Checkbox name="checkbox" onChange={() => addToArray("GET")} disabled={loading} />}
+                  label="GET"
+                />
+                <FormControlLabel
+                  input={<Checkbox name="checkbox" onChange={() => addToArray("POST")} disabled={loading} />}
                   label="POST"
                 />
-                <FormControlLabel input={<Checkbox name="checkbox" onChange={() => addToArray("PUT")} />} label="PUT" />
                 <FormControlLabel
-                  input={<Checkbox name="checkbox" onChange={() => addToArray("PATCH")} />}
+                  input={<Checkbox name="checkbox" onChange={() => addToArray("PUT")} disabled={loading} />}
+                  label="PUT"
+                />
+                <FormControlLabel
+                  input={<Checkbox name="checkbox" onChange={() => addToArray("PATCH")} disabled={loading} />}
                   label="PATCH"
                 />
                 <FormControlLabel
-                  input={<Checkbox name="checkbox" onChange={() => addToArray("DELETE")} />}
+                  input={<Checkbox name="checkbox" onChange={() => addToArray("DELETE")} disabled={loading} />}
                   label="DELETE"
                 />
               </FormFieldInput>
@@ -141,7 +147,7 @@ export const CreateEndpointFormTemplate: React.FC<CreateEndpointFormTemplateProp
               <FormFieldInput>
                 <FormFieldLabel>{t("Throws")}</FormFieldLabel>
                 {throws.length > 0 && (
-                  <SelectCreate options={throws} name="throws" {...{ register, errors, control }} />
+                  <SelectCreate options={throws} name="throws" {...{ register, errors, control }} disabled={loading} />
                 )}
               </FormFieldInput>
             </FormField>
@@ -164,6 +170,7 @@ export const CreateEndpointFormTemplate: React.FC<CreateEndpointFormTemplateProp
                     options={getSources.data.map((source: any) => ({ label: source.name, value: source.id }))}
                     name="source"
                     {...{ register, errors, control }}
+                    disabled={loading}
                   />
                 )}
               </FormFieldInput>
@@ -178,6 +185,7 @@ export const CreateEndpointFormTemplate: React.FC<CreateEndpointFormTemplateProp
                     options={getSchemas.data.map((schema: any) => ({ label: schema.name, value: schema.id }))}
                     name="schemas"
                     {...{ register, errors, control }}
+                    disabled={loading}
                   />
                 )}
               </FormFieldInput>
@@ -198,7 +206,7 @@ export const CreateEndpointFormTemplate: React.FC<CreateEndpointFormTemplateProp
           <FormField>
             <FormFieldInput>
               <FormFieldLabel>{t("Path Parts")}</FormFieldLabel>
-              <CreateKeyValue name="pathArray" {...{ register, errors, control }} />
+              <CreateKeyValue name="pathArray" {...{ register, errors, control }} disabled={loading} />
             </FormFieldInput>
           </FormField>
         </section>

--- a/pwa/src/templates/templateParts/endpointsForm/CreateEndpointsFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/endpointsForm/CreateEndpointsFormTemplate.tsx
@@ -1,16 +1,14 @@
 import * as React from "react";
 import * as styles from "./EndpointsFormTemplate.module.css";
 import { useForm } from "react-hook-form";
-import APIContext from "../../../apiService/apiContext";
 import FormField, {
   FormFieldGroup,
   FormFieldGroupLabel,
   FormFieldInput,
   FormFieldLabel,
 } from "@gemeente-denhaag/form-field";
-import { Alert, Button, Checkbox, FormControlLabel, Heading1 } from "@gemeente-denhaag/components-react";
+import { Button, Checkbox, FormControlLabel, Heading1 } from "@gemeente-denhaag/components-react";
 import { useTranslation } from "react-i18next";
-import APIService from "../../../apiService/apiService";
 import { InputText, SelectMultiple, SelectSingle, Textarea } from "@conduction/components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFloppyDisk } from "@fortawesome/free-solid-svg-icons";
@@ -29,10 +27,7 @@ interface CreateEndpointFormTemplateProps {
 
 export const CreateEndpointFormTemplate: React.FC<CreateEndpointFormTemplateProps> = ({ endpointId }) => {
   const { t } = useTranslation();
-  const API: APIService | null = React.useContext(APIContext);
   const [loading, setLoading] = React.useState<boolean>(false);
-  const [formError, setFormError] = React.useState<string>("");
-  const [pathParts, setPathParts] = React.useState<any[]>([]);
   const [methods, setMethods] = React.useState<any[]>([]);
   const [throws, setThrows] = React.useState<any[]>([]);
 
@@ -79,6 +74,10 @@ export const CreateEndpointFormTemplate: React.FC<CreateEndpointFormTemplateProp
   };
 
   React.useEffect(() => {
+    setLoading(createOrEditEndpoint.isLoading);
+  }, [createOrEditEndpoint.isLoading]);
+
+  React.useEffect(() => {
     setThrows([...predefinedSubscriberEvents]);
   }, []);
 
@@ -94,7 +93,7 @@ export const CreateEndpointFormTemplate: React.FC<CreateEndpointFormTemplateProp
             </Button>
           </div>
         </section>
-        {formError && <Alert text={formError} title={t("Oops, something went wrong")} variant="error" />}
+
         <div className={styles.gridContainer}>
           <div className={styles.grid}>
             <FormField>

--- a/pwa/src/templates/templateParts/endpointsForm/EditEndpointsFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/endpointsForm/EditEndpointsFormTemplate.tsx
@@ -1,16 +1,14 @@
 import * as React from "react";
 import * as styles from "./EndpointsFormTemplate.module.css";
 import { useForm } from "react-hook-form";
-import APIContext from "../../../apiService/apiContext";
 import FormField, {
   FormFieldGroup,
   FormFieldGroupLabel,
   FormFieldInput,
   FormFieldLabel,
 } from "@gemeente-denhaag/form-field";
-import { Alert, Button, Checkbox, FormControlLabel, Heading1 } from "@gemeente-denhaag/components-react";
+import { Button, Checkbox, FormControlLabel, Heading1 } from "@gemeente-denhaag/components-react";
 import { useTranslation } from "react-i18next";
-import APIService from "../../../apiService/apiService";
 import { InputText, SelectMultiple, SelectSingle, Textarea } from "@conduction/components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFloppyDisk, faMinus, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
@@ -34,9 +32,7 @@ export const EditEndpointFormTemplate: React.FC<EditEndpointFormTemplateProps> =
   const { t } = useTranslation();
   const { addOrRemoveDashboardCard, getDashboardCard } = useDashboardCard();
 
-  const API: APIService | null = React.useContext(APIContext);
   const [loading, setLoading] = React.useState<boolean>(false);
-  const [formError, setFormError] = React.useState<string>("");
   const [methods, setMethods] = React.useState<any[]>([]);
   const [pathParts, setPathParts] = React.useState<any[]>([]);
   const [throws, setThrows] = React.useState<any[]>([]);
@@ -127,6 +123,10 @@ export const EditEndpointFormTemplate: React.FC<EditEndpointFormTemplateProps> =
   };
 
   React.useEffect(() => {
+    setLoading(createOrEditEndpoint.isLoading);
+  }, [createOrEditEndpoint.isLoading]);
+
+  React.useEffect(() => {
     handleSetSelectFormValues(endpoint);
   }, [getSource.isSuccess]);
 
@@ -157,18 +157,18 @@ export const EditEndpointFormTemplate: React.FC<EditEndpointFormTemplateProps> =
               {t("Save")}
             </Button>
 
-            <Button className={styles.buttonIcon} onClick={addOrRemoveFromDashboard}>
+            <Button disabled={loading} className={styles.buttonIcon} onClick={addOrRemoveFromDashboard}>
               <FontAwesomeIcon icon={dashboardCard ? faMinus : faPlus} />
               {dashboardCard ? t("Remove from dashboard") : t("Add to dashboard")}
             </Button>
 
-            <Button className={clsx(styles.buttonIcon, styles.deleteButton)} onClick={handleDelete}>
+            <Button disabled={loading} className={clsx(styles.buttonIcon, styles.deleteButton)} onClick={handleDelete}>
               <FontAwesomeIcon icon={faTrash} />
               {t("Delete")}
             </Button>
           </div>
         </section>
-        {formError && <Alert text={formError} title={t("Oops, something went wrong")} variant="error" />}
+
         <div className={styles.gridContainer}>
           <div className={styles.grid}>
             <FormField>

--- a/pwa/src/templates/templateParts/endpointsForm/EditEndpointsFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/endpointsForm/EditEndpointsFormTemplate.tsx
@@ -201,6 +201,7 @@ export const EditEndpointFormTemplate: React.FC<EditEndpointFormTemplateProps> =
                       name="checkbox"
                       checked={endpoint.methods && endpoint.methods.includes("GET")}
                       onChange={() => addToArray("GET")}
+                      disabled={loading}
                     />
                   }
                   label="GET"
@@ -211,6 +212,7 @@ export const EditEndpointFormTemplate: React.FC<EditEndpointFormTemplateProps> =
                       name="checkbox"
                       checked={endpoint.methods && endpoint.methods.includes("POST")}
                       onChange={() => addToArray("POST")}
+                      disabled={loading}
                     />
                   }
                   label="POST"
@@ -221,6 +223,7 @@ export const EditEndpointFormTemplate: React.FC<EditEndpointFormTemplateProps> =
                       name="checkbox"
                       checked={endpoint.methods && endpoint.methods.includes("PUT")}
                       onChange={() => addToArray("PUT")}
+                      disabled={loading}
                     />
                   }
                   label="PUT"
@@ -231,6 +234,7 @@ export const EditEndpointFormTemplate: React.FC<EditEndpointFormTemplateProps> =
                       name="checkbox"
                       checked={endpoint.methods && endpoint.methods.includes("PATCH")}
                       onChange={() => addToArray("PATCH")}
+                      disabled={loading}
                     />
                   }
                   label="PATCH"
@@ -241,6 +245,7 @@ export const EditEndpointFormTemplate: React.FC<EditEndpointFormTemplateProps> =
                       name="checkbox"
                       checked={endpoint.methods && endpoint.methods.includes("DELETE")}
                       onChange={() => addToArray("DELETE")}
+                      disabled={loading}
                     />
                   }
                   label="DELETE"
@@ -254,7 +259,7 @@ export const EditEndpointFormTemplate: React.FC<EditEndpointFormTemplateProps> =
                 {throws.length <= 0 && <Skeleton height="50px" />}
 
                 {throws.length > 0 && (
-                  <SelectCreate options={throws} name="throws" {...{ register, errors, control }} />
+                  <SelectCreate options={throws} name="throws" {...{ register, errors, control }} disabled={loading} />
                 )}
               </FormFieldInput>
             </FormField>
@@ -277,6 +282,7 @@ export const EditEndpointFormTemplate: React.FC<EditEndpointFormTemplateProps> =
                     options={getSources.data.map((source: any) => ({ label: source.name, value: source.id }))}
                     name="source"
                     {...{ register, errors, control }}
+                    disabled={loading}
                   />
                 )}
               </FormFieldInput>
@@ -291,6 +297,7 @@ export const EditEndpointFormTemplate: React.FC<EditEndpointFormTemplateProps> =
                     options={getSchemas.data.map((schema: any) => ({ label: schema.name, value: schema.id }))}
                     name="schemas"
                     {...{ register, errors, control }}
+                    disabled={loading}
                   />
                 )}
               </FormFieldInput>
@@ -311,8 +318,12 @@ export const EditEndpointFormTemplate: React.FC<EditEndpointFormTemplateProps> =
           <FormField>
             <FormFieldInput>
               <FormFieldLabel>{t("Path Parts")}</FormFieldLabel>
-              {/* @ts-ignore */}
-              <CreateKeyValue name="pathArray" defaultValue={pathParts} {...{ register, errors, control }} />{" "}
+              <CreateKeyValue
+                name="pathArray"
+                defaultValue={pathParts}
+                {...{ register, errors, control }}
+                disabled={loading}
+              />
             </FormFieldInput>
           </FormField>
         </section>

--- a/pwa/src/templates/templateParts/formSaveButton/FormSaveButton.tsx
+++ b/pwa/src/templates/templateParts/formSaveButton/FormSaveButton.tsx
@@ -10,9 +10,10 @@ export type TAfterSuccessfulFormSubmit = "save" | "saveAndClose" | "saveAndCreat
 
 interface FormSaveButtonProps {
   setAfterSuccessfulFormSubmit: React.Dispatch<React.SetStateAction<TAfterSuccessfulFormSubmit>>;
+  disabled?: boolean;
 }
 
-const FormSaveButton: React.FC<FormSaveButtonProps> = ({ setAfterSuccessfulFormSubmit }) => {
+export const FormSaveButton: React.FC<FormSaveButtonProps> = ({ setAfterSuccessfulFormSubmit, disabled }) => {
   const { t } = useTranslation();
   const [menuEnabled, setMenuEnabled] = React.useState<boolean>(false);
 
@@ -29,6 +30,7 @@ const FormSaveButton: React.FC<FormSaveButtonProps> = ({ setAfterSuccessfulFormS
           type="submit"
           onClick={() => setAfterSuccessfulFormSubmit("save")}
           className={clsx(styles.buttonIcon, styles.primaryButton)}
+          {...{ disabled }}
         >
           <FontAwesomeIcon icon={faFloppyDisk} />
           {t("Save")}
@@ -40,6 +42,7 @@ const FormSaveButton: React.FC<FormSaveButtonProps> = ({ setAfterSuccessfulFormS
           }}
           onBlur={handleBlur}
           className={styles.secondaryButton}
+          {...{ disabled }}
         >
           <FontAwesomeIcon icon={faEllipsis} />
         </Button>
@@ -71,5 +74,3 @@ const FormSaveButton: React.FC<FormSaveButtonProps> = ({ setAfterSuccessfulFormS
     </div>
   );
 };
-
-export default FormSaveButton;

--- a/pwa/src/templates/templateParts/objectsFormTemplate/CreateObjectFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/objectsFormTemplate/CreateObjectFormTemplate.tsx
@@ -11,7 +11,7 @@ import { useSchema } from "../../../hooks/schema";
 import Skeleton from "react-loading-skeleton";
 import { SchemaFormTemplate } from "../schemaForm/SchemaFormTemplate";
 import { mapSelectInputFormData } from "../../../services/mapSelectInputFormData";
-import ObjectSaveButton, { TAfterSuccessfulFormSubmit } from "../formSaveButton/FormSaveButton";
+import { FormSaveButton, TAfterSuccessfulFormSubmit } from "../formSaveButton/FormSaveButton";
 import { navigate } from "gatsby";
 
 interface CreateObjectFormTemplateProps {
@@ -105,7 +105,7 @@ export const CreateObjectFormTemplate: React.FC<CreateObjectFormTemplateProps> =
           <Heading1>{t("Create Object")}</Heading1>
 
           <div className={styles.buttons}>
-            <ObjectSaveButton {...{ setAfterSuccessfulFormSubmit }} />
+            <FormSaveButton disabled={loading} {...{ setAfterSuccessfulFormSubmit }} />
           </div>
         </section>
 

--- a/pwa/src/templates/templateParts/objectsFormTemplate/EditObjectFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/objectsFormTemplate/EditObjectFormTemplate.tsx
@@ -13,7 +13,7 @@ import { useDashboardCard } from "../../../hooks/useDashboardCard";
 import { navigate } from "gatsby";
 import { mapSelectInputFormData } from "../../../services/mapSelectInputFormData";
 import Skeleton from "react-loading-skeleton";
-import ObjectSaveButton, { TAfterSuccessfulFormSubmit } from "../formSaveButton/FormSaveButton";
+import { FormSaveButton, TAfterSuccessfulFormSubmit } from "../formSaveButton/FormSaveButton";
 
 interface EditObjectFormTemplateProps {
   object: any;
@@ -94,9 +94,9 @@ export const EditObjectFormTemplate: React.FC<EditObjectFormTemplateProps> = ({ 
             <Heading1>{`Edit ${object._self.name}`}</Heading1>
 
             <div className={styles.buttons}>
-              <ObjectSaveButton {...{ setAfterSuccessfulFormSubmit }} />
+              <FormSaveButton disabled={loading} {...{ setAfterSuccessfulFormSubmit }} />
 
-              <Button className={styles.buttonIcon} onClick={addOrRemoveFromDashboard}>
+              <Button disabled={loading} className={styles.buttonIcon} onClick={addOrRemoveFromDashboard}>
                 <FontAwesomeIcon icon={dashboardCard ? faMinus : faPlus} />
                 {dashboardCard ? t("Remove from dashboard") : t("Add to dashboard")}
               </Button>

--- a/pwa/src/templates/templateParts/organizationsForm/OrganizationForm.tsx
+++ b/pwa/src/templates/templateParts/organizationsForm/OrganizationForm.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import * as styles from "./OrganizationFormTemplate.module.css";
 import FormField, { FormFieldInput, FormFieldLabel } from "@gemeente-denhaag/form-field";
-import { Alert, Button, Heading1 } from "@gemeente-denhaag/components-react";
+import { Button, Heading1 } from "@gemeente-denhaag/components-react";
 import { useTranslation } from "react-i18next";
 import { InputText, Textarea } from "@conduction/components";
 import { useForm } from "react-hook-form";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faFloppyDisk, faMinus, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faFloppyDisk, faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import { QueryClient } from "react-query";
 import { useOrganization } from "../../../hooks/organization";
 import { useDashboardCard } from "../../../hooks/useDashboardCard";
@@ -18,7 +18,6 @@ interface OrganizationFormProps {
 export const OrganizationForm: React.FC<OrganizationFormProps> = ({ organization }) => {
   const { t } = useTranslation();
   const { addOrRemoveDashboardCard, getDashboardCard } = useDashboardCard();
-  const [formError, setFormError] = React.useState<string>("");
   const [loading, setLoading] = React.useState<boolean>(false);
 
   const queryClient = new QueryClient();
@@ -44,6 +43,10 @@ export const OrganizationForm: React.FC<OrganizationFormProps> = ({ organization
   };
 
   React.useEffect(() => {
+    setLoading(createOrEditOrganization.isLoading);
+  }, [createOrEditOrganization.isLoading]);
+
+  React.useEffect(() => {
     organization && handleSetFormValues(organization);
   }, [organization]);
 
@@ -66,21 +69,15 @@ export const OrganizationForm: React.FC<OrganizationFormProps> = ({ organization
 
           {organization?.id && (
             <>
-              <Button className={styles.buttonIcon} onClick={addOrRemoveFromDashboard}>
+              <Button disabled={loading} className={styles.buttonIcon} onClick={addOrRemoveFromDashboard}>
                 <FontAwesomeIcon icon={dashboardCard ? faMinus : faPlus} />
                 {dashboardCard ? t("Remove from dashboard") : t("Add to dashboard")}
               </Button>
-
-              {/* <Button className={clsx(styles.buttonIcon, styles.deleteButton)} onClick={handleDelete}>
-                  <FontAwesomeIcon icon={faTrash} />
-                  {t("Delete")}
-                </Button> */}
             </>
           )}
         </div>
       </section>
 
-      {formError && <Alert text={formError} title={t("Oops, something went wrong")} variant="error" />}
       <div className={styles.gridContainer}>
         <div className={styles.grid}>
           <FormField>

--- a/pwa/src/templates/templateParts/propertyForm/CreatePropertyFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/propertyForm/CreatePropertyFormTemplate.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
 import * as styles from "./PropertyFormTemplate.module.css";
 import { useForm } from "react-hook-form";
-import APIContext from "../../../apiService/apiContext";
 import FormField, { FormFieldInput, FormFieldLabel } from "@gemeente-denhaag/form-field";
 import { Alert, Button, Heading1, Link, Tab, TabContext, TabPanel, Tabs } from "@gemeente-denhaag/components-react";
 import { useTranslation } from "react-i18next";
-import APIService from "../../../apiService/apiService";
 import { InputCheckbox, InputNumber, InputText, SelectSingle, Textarea, InputDate } from "@conduction/components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFloppyDisk } from "@fortawesome/free-solid-svg-icons";
@@ -25,7 +23,6 @@ interface CreatePropertyFormTemplateProps {
 
 export const CreatePropertyFormTemplate: React.FC<CreatePropertyFormTemplateProps> = ({ schemaId, propertyId }) => {
   const { t } = useTranslation();
-  const API: APIService | null = React.useContext(APIContext);
   const [loading, setLoading] = React.useState<boolean>(false);
   const [formError, setFormError] = React.useState<string>("");
   const [currentTab, setCurrentTab] = React.useState<number>(0);
@@ -84,6 +81,10 @@ export const CreatePropertyFormTemplate: React.FC<CreatePropertyFormTemplateProp
   } = useForm();
 
   const watchType = watch("type");
+
+  React.useEffect(() => {
+    setLoading(createOrEditAttribute.isLoading);
+  }, [createOrEditAttribute.isLoading]);
 
   React.useEffect(() => {
     if (!watchType) return;

--- a/pwa/src/templates/templateParts/propertyForm/EditPropertyFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/propertyForm/EditPropertyFormTemplate.tsx
@@ -30,7 +30,6 @@ export const EditPropertyFormTemplate: React.FC<EditPropertyFormTemplateProps> =
 }) => {
   const { t } = useTranslation();
 
-  const API: APIService | null = React.useContext(APIContext);
   const [loading, setLoading] = React.useState<boolean>(false);
   const [isImmutable, setIsImmutable] = React.useState<boolean>(false);
   const [formError, setFormError] = React.useState<string>("");
@@ -102,6 +101,10 @@ export const EditPropertyFormTemplate: React.FC<EditPropertyFormTemplateProps> =
   } = useForm();
 
   const watchType = watch("type");
+
+  React.useEffect(() => {
+    setLoading(createOrEditProperty.isLoading || deleteProperty.isLoading);
+  }, [createOrEditProperty.isLoading, deleteProperty.isLoading]);
 
   React.useEffect(() => {
     if (!getSchemas.isSuccess) return;
@@ -325,7 +328,11 @@ export const EditPropertyFormTemplate: React.FC<EditPropertyFormTemplateProps> =
                 {t("Save")}
               </Button>
 
-              <Button onClick={handleDeleteProperty} className={clsx(styles.buttonIcon, styles.deleteButton)}>
+              <Button
+                onClick={handleDeleteProperty}
+                className={clsx(styles.buttonIcon, styles.deleteButton)}
+                disabled={loading}
+              >
                 <FontAwesomeIcon icon={faTrash} />
                 {t("Delete")}
               </Button>

--- a/pwa/src/templates/templateParts/securityGroupsForm/CreateSecurityGroupFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/securityGroupsForm/CreateSecurityGroupFormTemplate.tsx
@@ -19,6 +19,7 @@ export const CreateSecurityGroupFormTemplate: React.FC<CreateSecurityGroupFormTe
   securityGroupId,
 }) => {
   const { t } = useTranslation();
+  const [loading, setLoading] = React.useState<boolean>(false);
 
   const queryClient = useQueryClient();
   const _useSecurityGroups = useSecurityGroup(queryClient);
@@ -39,6 +40,10 @@ export const CreateSecurityGroupFormTemplate: React.FC<CreateSecurityGroupFormTe
     createOrEditSecurityGroup.mutate({ payload, id: securityGroupId });
   };
 
+  React.useEffect(() => {
+    setLoading(createOrEditSecurityGroup.isLoading);
+  }, [createOrEditSecurityGroup.isLoading]);
+
   return (
     <div className={styles.container}>
       <form onSubmit={handleSubmit(onSubmit)}>
@@ -46,7 +51,7 @@ export const CreateSecurityGroupFormTemplate: React.FC<CreateSecurityGroupFormTe
           <Heading1>{t("Create Security Group")}</Heading1>
 
           <div className={styles.buttons}>
-            <Button className={styles.buttonIcon} type="submit">
+            <Button className={styles.buttonIcon} type="submit" disabled={loading}>
               <FontAwesomeIcon icon={faFloppyDisk} />
               {t("Save")}
             </Button>

--- a/pwa/src/templates/templateParts/securityGroupsForm/CreateSecurityGroupFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/securityGroupsForm/CreateSecurityGroupFormTemplate.tsx
@@ -62,28 +62,33 @@ export const CreateSecurityGroupFormTemplate: React.FC<CreateSecurityGroupFormTe
             <FormField>
               <FormFieldInput>
                 <FormFieldLabel>{t("Name")}</FormFieldLabel>
-                <InputText {...{ register, errors }} name="name" validation={{ required: true }} />
+                <InputText {...{ register, errors }} name="name" validation={{ required: true }} disabled={loading} />
               </FormFieldInput>
             </FormField>
 
             <FormField>
               <FormFieldInput>
                 <FormFieldLabel>{t("Config")}</FormFieldLabel>
-                <InputText {...{ register, errors }} name="config" />
+                <InputText {...{ register, errors }} name="config" disabled={loading} />
               </FormFieldInput>
             </FormField>
 
             <FormField>
               <FormFieldInput>
                 <FormFieldLabel>{t("Description")}</FormFieldLabel>
-                <Textarea {...{ register, errors }} name="description" validation={{ required: true }} />
+                <Textarea
+                  {...{ register, errors }}
+                  name="description"
+                  validation={{ required: true }}
+                  disabled={loading}
+                />
               </FormFieldInput>
             </FormField>
 
             <FormField>
               <FormFieldInput>
                 <FormFieldLabel>{t("Scopes")}</FormFieldLabel>
-                <SelectCreate options={[]} name="scopes" {...{ register, errors, control }} />
+                <SelectCreate options={[]} name="scopes" {...{ register, errors, control }} disabled={loading} />
               </FormFieldInput>
             </FormField>
           </div>

--- a/pwa/src/templates/templateParts/securityGroupsForm/EditSecurityGroupFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/securityGroupsForm/EditSecurityGroupFormTemplate.tsx
@@ -119,7 +119,7 @@ export const EditSecurityGroupFormTemplate: React.FC<EditSecurityGroupFormTempla
             <FormField>
               <FormFieldInput>
                 <FormFieldLabel>{t("Scopes")}</FormFieldLabel>
-                <SelectCreate options={[]} name="scopes" {...{ register, errors, control }} />
+                <SelectCreate options={[]} name="scopes" {...{ register, errors, control }} disabled={loading} />
               </FormFieldInput>
             </FormField>
           </div>

--- a/pwa/src/templates/templateParts/securityGroupsForm/EditSecurityGroupFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/securityGroupsForm/EditSecurityGroupFormTemplate.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
 import * as styles from "./SecurityGroupFormTemplate.module.css";
 import { useForm } from "react-hook-form";
-import APIContext from "../../../apiService/apiContext";
 import FormField, { FormFieldInput, FormFieldLabel } from "@gemeente-denhaag/form-field";
-import { Alert, Button, Heading1 } from "@gemeente-denhaag/components-react";
+import { Button, Heading1 } from "@gemeente-denhaag/components-react";
 import { useTranslation } from "react-i18next";
-import APIService from "../../../apiService/apiService";
 import { InputText, Textarea } from "@conduction/components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFloppyDisk, faTrash } from "@fortawesome/free-solid-svg-icons";
@@ -24,10 +22,7 @@ export const EditSecurityGroupFormTemplate: React.FC<EditSecurityGroupFormTempla
   securityGroupId,
 }) => {
   const { t } = useTranslation();
-
-  const API: APIService | null = React.useContext(APIContext);
   const [loading, setLoading] = React.useState<boolean>(false);
-  const [formError, setFormError] = React.useState<string>("");
 
   const queryClient = useQueryClient();
   const _useSecurityGroups = useSecurityGroup(queryClient);
@@ -53,6 +48,10 @@ export const EditSecurityGroupFormTemplate: React.FC<EditSecurityGroupFormTempla
   };
 
   React.useEffect(() => {
+    setLoading(createOrEditSecurityGroup.isLoading || deleteSecurityGroup.isLoading);
+  }, [createOrEditSecurityGroup.isLoading, deleteSecurityGroup.isLoading]);
+
+  React.useEffect(() => {
     handleSetFormValues(securityGroup);
   }, []);
 
@@ -65,7 +64,9 @@ export const EditSecurityGroupFormTemplate: React.FC<EditSecurityGroupFormTempla
   };
 
   const handleDelete = () => {
-    deleteSecurityGroup.mutate({ id: securityGroupId });
+    const confirmDeletion = confirm("Are you sure you want to delete this security group?");
+
+    confirmDeletion && deleteSecurityGroup.mutate({ id: securityGroupId });
   };
 
   return (
@@ -80,13 +81,13 @@ export const EditSecurityGroupFormTemplate: React.FC<EditSecurityGroupFormTempla
               {t("Save")}
             </Button>
 
-            <Button className={clsx(styles.buttonIcon, styles.deleteButton)} onClick={handleDelete}>
+            <Button className={clsx(styles.buttonIcon, styles.deleteButton)} onClick={handleDelete} disabled={loading}>
               <FontAwesomeIcon icon={faTrash} />
               {t("Delete")}
             </Button>
           </div>
         </section>
-        {formError && <Alert text={formError} title={t("Oops, something went wrong")} variant="error" />}
+
         <div className={styles.gridContainer}>
           <div className={styles.grid}>
             <FormField>

--- a/pwa/src/templates/templateParts/sourcesForm/CreateSourceFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/sourcesForm/CreateSourceFormTemplate.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
 import * as styles from "./SourcesFormTemplate.module.css";
 import { useForm } from "react-hook-form";
-import APIContext from "../../../apiService/apiContext";
 import FormField, { FormFieldInput, FormFieldLabel } from "@gemeente-denhaag/form-field";
-import { Alert, Button, Heading1, Tab, TabContext, TabPanel, Tabs } from "@gemeente-denhaag/components-react";
+import { Button, Heading1, Tab, TabContext, TabPanel, Tabs } from "@gemeente-denhaag/components-react";
 import { useTranslation } from "react-i18next";
-import APIService from "../../../apiService/apiService";
 import { InputCheckbox, InputText, SelectSingle, Textarea } from "@conduction/components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFloppyDisk, faInfoCircle } from "@fortawesome/free-solid-svg-icons";
@@ -24,9 +22,7 @@ interface CreateSourceFormTemplateProps {
 
 export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> = ({ sourceId }) => {
   const { t } = useTranslation();
-  const API: APIService = React.useContext(APIContext);
   const [loading, setLoading] = React.useState<boolean>(false);
-  const [formError, setFormError] = React.useState<string>("");
   const [currentTab, setCurrentTab] = React.useState<number>(0);
   const [selectedAuth, setSelectedAuth] = React.useState<any>(null);
   const [headers, setHeaders] = React.useState<IKeyValue[]>([]);
@@ -43,14 +39,6 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
   const queryClient = useQueryClient();
   const _useSources = useSource(queryClient);
   const createOrEditSource = _useSources.createOrEdit(sourceId);
-
-  const typeSelectOptions = [
-    { label: "JSON", value: "json" },
-    { label: "SML", value: "xml" },
-    { label: "SOAP", value: "soap" },
-    { label: "FTP", value: "ftp" },
-    { label: "SFTP", value: "sftp" },
-  ];
 
   const authSelectOptions = [
     { label: "No Auth", value: "none" },
@@ -70,6 +58,10 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
   const watchAuth = watch("auth");
   const watchHeaders = watch("headers");
   const watchQuery = watch("query");
+
+  React.useEffect(() => {
+    setLoading(createOrEditSource.isLoading);
+  }, [createOrEditSource.isLoading]);
 
   React.useEffect(() => {
     if (!watchAuth) return;
@@ -152,7 +144,6 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
           </Tabs>
 
           <TabPanel className={styles.tabPanel} value="0">
-            {formError && <Alert text={formError} title={t("Oops, something went wrong")} variant="error" />}
             <div className={styles.gridContainer}>
               <div className={styles.grid}>
                 <FormField>
@@ -216,7 +207,6 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
           </TabPanel>
 
           <TabPanel className={styles.tabPanel} value="3">
-            {formError && <Alert text={formError} title={t("Oops, something went wrong")} variant="error" />}
             <div className={styles.gridContainer}>
               <div className={styles.grid}>
                 <FormField>

--- a/pwa/src/templates/templateParts/sourcesForm/CreateSourceFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/sourcesForm/CreateSourceFormTemplate.tsx
@@ -199,11 +199,16 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
           </TabPanel>
 
           <TabPanel className={styles.tabPanel} value="1">
-            <CreateKeyValue name="query" defaultValue={query} {...{ register, errors, control }} />
+            <CreateKeyValue name="query" disabled={loading} defaultValue={query} {...{ register, errors, control }} />
           </TabPanel>
 
           <TabPanel className={styles.tabPanel} value="2">
-            <CreateKeyValue name="headers" defaultValue={headers} {...{ register, errors, control }} />
+            <CreateKeyValue
+              disabled={loading}
+              name="headers"
+              defaultValue={headers}
+              {...{ register, errors, control }}
+            />
           </TabPanel>
 
           <TabPanel className={styles.tabPanel} value="3">
@@ -230,7 +235,7 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                         />
                       </a>
                     </div>
-                    <InputFloat {...{ register, errors }} name="connect_timeout" disabled={loading} />
+                    <InputFloat disabled={loading} {...{ register, errors }} name="connect_timeout" />
                   </FormFieldInput>
                 </FormField>
 
@@ -254,7 +259,7 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                       />
                     </a>
                   </div>
-                  <InputCheckbox name="debug" label="True" {...{ register, errors }} />
+                  <InputCheckbox name="debug" disabled={loading} label="True" {...{ register, errors }} />
                 </FormField>
 
                 <FormField>
@@ -278,6 +283,7 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                     </a>
                   </div>
                   <ToggleButton
+                    disabled={loading}
                     layoutClassName={styles.toggleButton}
                     startLabel="string"
                     endLabel="boolean"
@@ -290,7 +296,7 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                   />
                   <div className={styles.expectFormField}>
                     {advancedSwitch.decodeContent === "string" && (
-                      <Textarea name="decode_content_str" {...{ register, errors }} />
+                      <Textarea disabled={loading} name="decode_content_str" {...{ register, errors }} />
                     )}
                     {advancedSwitch.decodeContent === "boolean" && (
                       <span className={styles.checkboxInput}>
@@ -317,6 +323,7 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                     </a>
                   </div>
                   <ToggleButton
+                    disabled={loading}
                     layoutClassName={styles.toggleButton}
                     startLabel="int"
                     endLabel="float"
@@ -328,8 +335,12 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                     }
                   />
                   <div className={styles.expectFormField}>
-                    {advancedSwitch.delay === "int" && <InputNumber name="delay" {...{ register, errors }} />}
-                    {advancedSwitch.delay === "float" && <InputFloat name="delay" {...{ register, errors }} />}
+                    {advancedSwitch.delay === "int" && (
+                      <InputNumber disabled={loading} name="delay" {...{ register, errors }} />
+                    )}
+                    {advancedSwitch.delay === "float" && (
+                      <InputFloat disabled={loading} name="delay" {...{ register, errors }} />
+                    )}
                   </div>
                 </FormField>
 
@@ -350,6 +361,7 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                     </a>
                   </div>
                   <ToggleButton
+                    disabled={loading}
                     layoutClassName={styles.toggleButton}
                     startLabel="int"
                     endLabel="boolean"
@@ -366,7 +378,9 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                         <InputCheckbox name="expect_bool" label="True" {...{ register, errors }} />
                       </span>
                     )}
-                    {advancedSwitch.expect === "int" && <InputNumber name="expect_int" {...{ register, errors }} />}
+                    {advancedSwitch.expect === "int" && (
+                      <InputNumber disabled={loading} name="expect_int" {...{ register, errors }} />
+                    )}
                   </div>
                 </FormField>
 
@@ -387,7 +401,7 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                         />
                       </a>
                     </div>
-                    <InputText {...{ register, errors }} name="force_ip_resolve" />
+                    <InputText disabled={loading} {...{ register, errors }} name="force_ip_resolve" />
                   </FormFieldInput>
                 </FormField>
 
@@ -412,6 +426,7 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                     </a>
                   </div>
                   <ToggleButton
+                    disabled={loading}
                     layoutClassName={styles.toggleButton}
                     startLabel="string"
                     endLabel="boolean"
@@ -425,10 +440,12 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                   <div className={styles.expectFormField}>
                     {advancedSwitch.verify === "boolean" && (
                       <span className={styles.checkboxInput}>
-                        <InputCheckbox name="verify_bool" label="True" {...{ register, errors }} />
+                        <InputCheckbox disabled={loading} name="verify_bool" label="True" {...{ register, errors }} />
                       </span>
                     )}
-                    {advancedSwitch.verify === "string" && <InputText name="verify_str" {...{ register, errors }} />}
+                    {advancedSwitch.verify === "string" && (
+                      <InputText disabled={loading} name="verify_str" {...{ register, errors }} />
+                    )}
                   </div>
                 </FormField>
 
@@ -446,7 +463,7 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                         <FontAwesomeIcon data-tip={"Protocol version to use with the request."} icon={faInfoCircle} />
                       </a>
                     </div>
-                    <InputText {...{ register, errors }} name="version" />
+                    <InputText disabled={loading} {...{ register, errors }} name="version" />
                   </FormFieldInput>
                 </FormField>
 
@@ -467,7 +484,7 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                         />
                       </a>
                     </div>
-                    <InputFloat {...{ register, errors }} name="read_timeout" />
+                    <InputFloat disabled={loading} {...{ register, errors }} name="read_timeout" />
                   </FormFieldInput>
                 </FormField>
               </div>
@@ -493,7 +510,7 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                       />
                     </a>
                   </div>
-                  <Textarea {...{ register, errors }} name="proxy" />
+                  <Textarea disabled={loading} {...{ register, errors }} name="proxy" />
                 </FormFieldInput>
               </FormField>
 
@@ -519,6 +536,7 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                     </a>
                   </div>
                   <ToggleButton
+                    disabled={loading}
                     layoutClassName={styles.toggleButton}
                     startLabel="int"
                     endLabel="boolean"
@@ -532,11 +550,16 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                   <div className={styles.expectFormField}>
                     {advancedSwitch.idnConversion === "boolean" && (
                       <span className={styles.checkboxInput}>
-                        <InputCheckbox name="idn_conversion_bool" label="True" {...{ register, errors }} />
+                        <InputCheckbox
+                          disabled={loading}
+                          name="idn_conversion_bool"
+                          label="True"
+                          {...{ register, errors }}
+                        />
                       </span>
                     )}
                     {advancedSwitch.idnConversion === "int" && (
-                      <InputNumber name="idn_conversion_int" {...{ register, errors }} />
+                      <InputNumber disabled={loading} name="idn_conversion_int" {...{ register, errors }} />
                     )}
                   </div>
                 </FormField>
@@ -561,7 +584,7 @@ export const CreateSourceFormTemplate: React.FC<CreateSourceFormTemplateProps> =
                       />
                     </a>
                   </div>
-                  <InputCheckbox name="https_errors" label="True" {...{ register, errors }} />
+                  <InputCheckbox disabled={loading} name="https_errors" label="True" {...{ register, errors }} />
                 </FormField>
               </div>
             </div>

--- a/pwa/src/templates/templateParts/sourcesForm/EditSourcesFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/sourcesForm/EditSourcesFormTemplate.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
 import * as styles from "./SourcesFormTemplate.module.css";
 import { useForm } from "react-hook-form";
-import APIContext from "../../../apiService/apiContext";
 import FormField, { FormFieldInput, FormFieldLabel } from "@gemeente-denhaag/form-field";
 import { Button, Heading1, Tab, TabContext, TabPanel, Tabs } from "@gemeente-denhaag/components-react";
 import { useTranslation } from "react-i18next";
-import APIService from "../../../apiService/apiService";
 import { InputCheckbox, InputNumber, InputText, SelectSingle, Tag, Textarea } from "@conduction/components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFloppyDisk, faInfoCircle, faMinus, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
@@ -34,11 +32,10 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
   const { t, i18n } = useTranslation();
   const { addOrRemoveDashboardCard, getDashboardCard } = useDashboardCard();
 
-  const API: APIService | null = React.useContext(APIContext);
   const [loading, setLoading] = React.useState<boolean>(false);
   const [currentTab, setCurrentTab] = React.useState<number>(0);
   const [selectedAuth, setSelectedAuth] = React.useState<any>(null);
-  const [isLoading, setIsLoading] = React.useContext(IsLoadingContext);
+  const [isLoading] = React.useContext(IsLoadingContext);
   const [headers, setHeaders] = React.useState<IKeyValue[]>([]);
   const [query, setQuery] = React.useState<IKeyValue[]>([]);
 
@@ -117,6 +114,10 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
   const watchAuth = watch("auth");
   const watchHeaders = watch("headers");
   const watchQuery = watch("query");
+
+  React.useEffect(() => {
+    setLoading(createOrEditSource.isLoading);
+  }, [createOrEditSource.isLoading]);
 
   React.useEffect(() => {
     if (!watchAuth) return;
@@ -264,13 +265,17 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
             <Button
               className={styles.buttonIcon}
               onClick={addOrRemoveFromDashboard}
-              disabled={isLoading.addDashboardCard}
+              disabled={isLoading.addDashboardCard || loading}
             >
               <FontAwesomeIcon icon={dashboardCard ? faMinus : faPlus} />
               {dashboardCard ? t("Remove from dashboard") : t("Add to dashboard")}
             </Button>
 
-            <Button className={clsx(styles.buttonIcon, styles.deleteButton)} onClick={() => handleDelete(source.id)}>
+            <Button
+              disabled={loading}
+              className={clsx(styles.buttonIcon, styles.deleteButton)}
+              onClick={() => handleDelete(source.id)}
+            >
               <FontAwesomeIcon icon={faTrash} />
               {t("Delete")}
             </Button>

--- a/pwa/src/templates/templateParts/sourcesForm/EditSourcesFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/sourcesForm/EditSourcesFormTemplate.tsx
@@ -310,6 +310,7 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                     {errors["name"] && <ErrorMessage message={errors["name"].message} />}
                   </FormFieldInput>
                 </FormField>
+
                 <FormField>
                   <FormFieldLabel>{t("Status")}</FormFieldLabel>
                   <div className={clsx(styles[getStatusColor(source.status ?? "no known status")])}>
@@ -319,12 +320,14 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                     />
                   </div>
                 </FormField>
+
                 <FormField>
                   <FormFieldInput className={styles.flex}>
                     <FormFieldLabel>{t("Created")}</FormFieldLabel>
                     <Tag label={translateDate(i18n.language, source.dateCreated) ?? "-"} />
                   </FormFieldInput>
                 </FormField>
+
                 <FormField>
                   <FormFieldInput className={styles.flex}>
                     <FormFieldLabel>{t("Modified")}</FormFieldLabel>
@@ -332,6 +335,7 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                   </FormFieldInput>
                 </FormField>
               </div>
+
               <FormField>
                 <FormFieldInput>
                   <FormFieldLabel>{t("Description")}</FormFieldLabel>
@@ -372,11 +376,16 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
           </TabPanel>
 
           <TabPanel className={styles.tabPanel} value="1">
-            <CreateKeyValue name="query" defaultValue={query} {...{ register, errors, control }} />
+            <CreateKeyValue disabled={loading} name="query" defaultValue={query} {...{ register, errors, control }} />
           </TabPanel>
 
           <TabPanel className={styles.tabPanel} value="2">
-            <CreateKeyValue name="headers" defaultValue={headers} {...{ register, errors, control }} />
+            <CreateKeyValue
+              disabled={loading}
+              name="headers"
+              defaultValue={headers}
+              {...{ register, errors, control }}
+            />
           </TabPanel>
 
           <TabPanel className={styles.tabPanel} value="3">
@@ -427,7 +436,7 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                       />
                     </a>
                   </div>
-                  <InputCheckbox name="debug" label="True" {...{ register, errors }} />
+                  <InputCheckbox disabled={loading} name="debug" label="True" {...{ register, errors }} />
                 </FormField>
 
                 <FormField>
@@ -451,6 +460,7 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                     </a>
                   </div>
                   <ToggleButton
+                    disabled={loading}
                     layoutClassName={styles.toggleButton}
                     startLabel="string"
                     endLabel="boolean"
@@ -464,11 +474,16 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                   />
                   <div className={styles.expectFormField}>
                     {advancedSwitch.decodeContent === "string" && (
-                      <TextArea name="decode_content_str" {...{ register, errors }} />
+                      <TextArea disabled={loading} name="decode_content_str" {...{ register, errors }} />
                     )}
                     {advancedSwitch.decodeContent === "boolean" && (
                       <span className={styles.checkboxInput}>
-                        <InputCheckbox name="decode_content_bool" label="True" {...{ register, errors }} />
+                        <InputCheckbox
+                          disabled={loading}
+                          name="decode_content_bool"
+                          label="True"
+                          {...{ register, errors }}
+                        />
                       </span>
                     )}
                   </div>
@@ -491,6 +506,7 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                     </a>
                   </div>
                   <ToggleButton
+                    disabled={loading}
                     layoutClassName={styles.toggleButton}
                     startLabel="int"
                     endLabel="float"
@@ -503,8 +519,12 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                     }
                   />
                   <div className={styles.expectFormField}>
-                    {advancedSwitch.delay === "int" && <InputNumber name="delay" {...{ register, errors }} />}
-                    {advancedSwitch.delay === "float" && <InputFloat name="delay" {...{ register, errors }} />}
+                    {advancedSwitch.delay === "int" && (
+                      <InputNumber disabled={loading} name="delay" {...{ register, errors }} />
+                    )}
+                    {advancedSwitch.delay === "float" && (
+                      <InputFloat disabled={loading} name="delay" {...{ register, errors }} />
+                    )}
                   </div>
                 </FormField>
 
@@ -525,6 +545,7 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                     </a>
                   </div>
                   <ToggleButton
+                    disabled={loading}
                     layoutClassName={styles.toggleButton}
                     startLabel="int"
                     endLabel="boolean"
@@ -539,10 +560,12 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                   <div className={styles.expectFormField}>
                     {advancedSwitch.expect === "boolean" && (
                       <span className={styles.checkboxInput}>
-                        <InputCheckbox name="expect_bool" label="True" {...{ register, errors }} />
+                        <InputCheckbox disabled={loading} name="expect_bool" label="True" {...{ register, errors }} />
                       </span>
                     )}
-                    {advancedSwitch.expect === "int" && <InputNumber name="expect_int" {...{ register, errors }} />}
+                    {advancedSwitch.expect === "int" && (
+                      <InputNumber disabled={loading} name="expect_int" {...{ register, errors }} />
+                    )}
                   </div>
                 </FormField>
 
@@ -563,7 +586,7 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                         />
                       </a>
                     </div>
-                    <InputText {...{ register, errors }} name="force_ip_resolve" />
+                    <InputText disabled={loading} {...{ register, errors }} name="force_ip_resolve" />
                   </FormFieldInput>
                 </FormField>
 
@@ -588,6 +611,7 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                     </a>
                   </div>
                   <ToggleButton
+                    disabled={loading}
                     layoutClassName={styles.toggleButton}
                     startLabel="string"
                     endLabel="boolean"
@@ -602,10 +626,12 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                   <div className={styles.expectFormField}>
                     {advancedSwitch.verify === "boolean" && (
                       <span className={styles.checkboxInput}>
-                        <InputCheckbox name="verify_bool" label="True" {...{ register, errors }} />
+                        <InputCheckbox disabled={loading} name="verify_bool" label="True" {...{ register, errors }} />
                       </span>
                     )}
-                    {advancedSwitch.verify === "string" && <InputText name="verify_str" {...{ register, errors }} />}
+                    {advancedSwitch.verify === "string" && (
+                      <InputText disabled={loading} name="verify_str" {...{ register, errors }} />
+                    )}
                   </div>
                 </FormField>
 
@@ -623,7 +649,7 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                         <FontAwesomeIcon data-tip={"Protocol version to use with the request."} icon={faInfoCircle} />
                       </a>
                     </div>
-                    <InputText {...{ register, errors }} name="version" />
+                    <InputText disabled={loading} {...{ register, errors }} name="version" />
                   </FormFieldInput>
                 </FormField>
 
@@ -644,7 +670,7 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                         />
                       </a>
                     </div>
-                    <InputFloat {...{ register, errors }} name="read_timeout" />
+                    <InputFloat disabled={loading} {...{ register, errors }} name="read_timeout" />
                   </FormFieldInput>
                 </FormField>
               </div>
@@ -670,7 +696,7 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                       />
                     </a>
                   </div>
-                  <Textarea {...{ register, errors }} name="proxy" />
+                  <Textarea disabled={loading} {...{ register, errors }} name="proxy" />
                 </FormFieldInput>
               </FormField>
 
@@ -696,6 +722,7 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                     </a>
                   </div>
                   <ToggleButton
+                    disabled={loading}
                     layoutClassName={styles.toggleButton}
                     startLabel="int"
                     endLabel="boolean"
@@ -710,11 +737,16 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                   <div className={styles.expectFormField}>
                     {advancedSwitch.idnConversion === "boolean" && (
                       <span className={styles.checkboxInput}>
-                        <InputCheckbox name="idn_conversion_bool" label="True" {...{ register, errors }} />
+                        <InputCheckbox
+                          disabled={loading}
+                          name="idn_conversion_bool"
+                          label="True"
+                          {...{ register, errors }}
+                        />
                       </span>
                     )}
                     {advancedSwitch.idnConversion === "int" && (
-                      <InputNumber name="idn_conversion_int" {...{ register, errors }} />
+                      <InputNumber disabled={loading} name="idn_conversion_int" {...{ register, errors }} />
                     )}
                   </div>
                 </FormField>
@@ -739,7 +771,7 @@ export const SourcesFormTemplate: React.FC<SourcesFormTemplateProps> = ({ source
                       />
                     </a>
                   </div>
-                  <InputCheckbox name="https_errors" label="True" {...{ register, errors }} />
+                  <InputCheckbox disabled={loading} name="https_errors" label="True" {...{ register, errors }} />
                 </FormField>
               </div>
             </div>


### PR DESCRIPTION
This pull request includes the refactoring on every form (exception forms, underneath in the to-dos).

1. All forms now have a loading state, which is set based on the API-calls with the gateway;
2. All forms loading state is reset when the the calls are no longer loading;
3. All form elements within the form are disabled whilst loading is true;

Also, all unused code has been removed from the forms and some small refactors have been done where necessary. 

To-dos (I will be creating JIRA issues for these):

1. Above changes in Schemas, Applications, Users and Authentications (the acceptance criteria of Schemas are more complex and the other forms have a different structure than all other forms);
2. ToggleButton and regular Checkbox refactor: they need a `cursor: not-allowed` when they're disabled;
3. All `Add to dashboard` buttons should be included in the `loading` state, which they currently are not (except for one form, I think);
4. **We need to make a decision on how we're going to be including the save buttons, when we change to one form instead of two.**