### PR TITLE
REFACTOR Action form and Button

### DIFF
--- a/pwa/src/apiService/resources/action.ts
+++ b/pwa/src/apiService/resources/action.ts
@@ -65,7 +65,7 @@ export default class Action {
 
     const { data } = await Send(this._instance, "POST", `/admin/run_action/${id}`, payload, {
       loading: "Running Action...",
-      success: "Run succesful.",
+      success: "Action succesfully ran.",
     });
 
     return data;

--- a/pwa/src/components/button/Button.module.css
+++ b/pwa/src/components/button/Button.module.css
@@ -6,13 +6,13 @@
   margin-inline-end: var(--gateway-ui-size-xs);
 }
 
-.runAction {
+.success {
   --denhaag-button-primary-action-background-color: var(
     --gateway-ui-color-green
   );
 }
 
-.runAction:hover {
+.success:hover {
   --denhaag-button-primary-action-hover-background-color: var(
     --gateway-ui-color-dark-green
   );

--- a/pwa/src/components/button/Button.tsx
+++ b/pwa/src/components/button/Button.tsx
@@ -8,7 +8,7 @@ import clsx from "clsx";
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   label: string | JSX.Element;
-  variant: "primary" | "danger" | "runAction";
+  variant: "primary" | "danger" | "success";
   icon: IconDefinition;
 
   onClick?: (event: React.MouseEvent<HTMLButtonElement> | React.TouchEvent<HTMLButtonElement>) => any;

--- a/pwa/src/styling/design-tokens/gateway-ui-design-tokens.css
+++ b/pwa/src/styling/design-tokens/gateway-ui-design-tokens.css
@@ -59,8 +59,8 @@
   --gateway-ui-color-darkgrey: rgb(204, 204, 204);
   --gateway-ui-color-red: red;
   --gateway-ui-color-dark-red: rgb(146, 2, 2);
-  --gateway-ui-color-green: green;
-  --gateway-ui-color-dark-green: darkgreen;
+  --gateway-ui-color-green: #28a745;
+  --gateway-ui-color-dark-green: #218838;
   --gateway-ui-color-orange: orange;
   --gateway-ui-color-status-green: #69b090;
   --gateway-ui-color-status-red: #dd3c49;

--- a/pwa/src/templates/actionsDetailTemplate/ActionsDetailsTemplate.tsx
+++ b/pwa/src/templates/actionsDetailTemplate/ActionsDetailsTemplate.tsx
@@ -72,7 +72,7 @@ export const ActionsDetailTemplate: React.FC<ActionsDetailsTemplateProps> = ({ a
             handleToggleDashboard={{ handleToggle: toggleFromDashboard, isActive: !!dashboardCard }}
             showTitleTooltip
             customElements={
-              <Button label={t("Run")} icon={faPlay} variant="runAction" onClick={() => handleRunAction({})} />
+              <Button label={t("Run")} icon={faPlay} variant="success" onClick={() => handleRunAction({})} />
             }
           />
 

--- a/pwa/src/templates/templateParts/actionsForm/ActionFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/actionsForm/ActionFormTemplate.tsx
@@ -86,7 +86,7 @@ export const ActionFormTemplate: React.FC<ActionFormTemplateProps> = ({ action }
       delete payload[key];
     }
 
-    createOrEditAction.mutate({ payload });
+    createOrEditAction.mutate({ payload, id: action?.id });
 
     action && queryClient.setQueryData(["actions", action.id], payload);
   };


### PR DESCRIPTION
Editing actions was creating new ones due to not sending `action.id`.