### PR TITLE
TEMPORARILY REMOVE array support for generated forms

### DIFF
--- a/pwa/src/services/mapGatewaySchemaToInputValues.ts
+++ b/pwa/src/services/mapGatewaySchemaToInputValues.ts
@@ -1,12 +1,12 @@
 export const mapGatewaySchemaToInputValues = (value: any): any => {
   switch (value.type) {
-    case "array":
-      if (Array.isArray(value.value) || value.value === undefined || value.value === null) {
-        return value.value?.map((item: any) => ({ key: item.key, value: item.value }));
-      } else {
-        const objectToArray = Object.entries(value.value).map(([key, value]) => ({ key, value: value }));
-        return objectToArray?.map((item: any) => ({ key: item.key, value: item.value }));
-      }
+    // case "array":
+    //   if (Array.isArray(value.value) || value.value === undefined || value.value === null) {
+    //     return value.value?.map((item: any) => ({ key: item.key, value: item.value }));
+    //   } else {
+    //     const objectToArray = Object.entries(value.value).map(([key, value]) => ({ key, value: value }));
+    //     return objectToArray?.map((item: any) => ({ key: item.key, value: item.value }));
+    //   }
 
     case "boolean":
     case "integer":

--- a/pwa/src/templates/templateParts/schemaForm/SchemaFormTemplate.tsx
+++ b/pwa/src/templates/templateParts/schemaForm/SchemaFormTemplate.tsx
@@ -315,14 +315,15 @@ const FormFieldGroup: React.FC<FormFieldGroupProps & ReactHookFormProps> = ({
           />
         )}
 
-        {type === "array" && (
+        {type === "array" && <>Properties of type array are not yet supported.</>}
+        {/* {type === "array" && (
           <>
             <CreateKeyValue
               disabled={disabled || readOnly}
               {...{ register, errors, control, placeholder, name, defaultValue }}
             />
           </>
-        )}
+        )} */}
 
         {type === "object" && (
           <SchemaTypeObject


### PR DESCRIPTION
This array logic is breaking live environments due to the environments not sending the expected data.