### PR TITLE
REFACTOR dependencies

### DIFF
--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -8,10 +8,11 @@
       "name": "skeleton-app",
       "version": "1.0.0",
       "dependencies": {
-        "@conduction/components": "2.1.27",
+        "@conduction/components": "2.2.0",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
+        "@gemeente-denhaag/button": "^0.2.3-alpha.323",
         "@gemeente-denhaag/components-react": "^0.1.1-alpha.143",
         "@gemeente-denhaag/design-tokens-components": "^0.2.3-alpha.178",
         "@gemeente-denhaag/form-field": "^0.1.1-alpha.67",
@@ -19,6 +20,8 @@
         "@gemeente-denhaag/sidenav": "^0.1.0-alpha.1",
         "@gemeente-denhaag/table": "^0.1.1-alpha.87",
         "@gemeente-denhaag/textarea": "^0.1.1-alpha.65",
+        "@material-ui/core": "^4.12.4",
+        "@material-ui/lab": "^4.0.0-alpha.61",
         "@monaco-editor/react": "^4.4.6",
         "@opengemeenten/iconset-react": "^1.0.1",
         "axios": "^0.25.0",
@@ -32,16 +35,16 @@
         "i18next": "^21.6.16",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
-        "react": "^17.0.1",
+        "react": "^18.2.0",
         "react-collapsible": "^2.10.0",
-        "react-dom": "^17.0.1",
+        "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.3",
         "react-favicon": "^1.0.1",
         "react-helmet": "^6.1.0",
         "react-hook-form": "7.29.0",
         "react-hot-toast": "^2.4.0",
         "react-i18next": "^11.16.6",
-        "react-loading-skeleton": "^3.1.0",
+        "react-loading-skeleton": "3.0.0",
         "react-minimal-pie-chart": "^8.4.0",
         "react-paginate": "^8.1.4",
         "react-query": "^3.34.19",
@@ -51,7 +54,7 @@
         "@types/dateformat": "^5.0.0",
         "@types/node": "^17.0.23",
         "@types/react": "^17.0.43",
-        "@types/react-dom": "^17.0.14",
+        "@types/react-dom": "^18.2.0",
         "@types/react-helmet": "^6.1.5",
         "typescript": "^4.6.3"
       }
@@ -1766,10 +1769,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.13",
-      "license": "MIT",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
+      "integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1785,6 +1789,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@babel/template": {
       "version": "7.20.7",
@@ -1856,31 +1865,27 @@
       }
     },
     "node_modules/@conduction/components": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/@conduction/components/-/components-2.1.27.tgz",
-      "integrity": "sha512-e/l5b44BNJp1r+rTkZhvVjEuaF/+3yNpHl0ToLr/bZsn57Brxs9imaDXSkAlrRUXRSBPEfXqtifwmhzJk1Davg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@conduction/components/-/components-2.2.0.tgz",
+      "integrity": "sha512-bAJHU3fn+e3lH2kZXAfHJOhdITVbV8tyqIBU72YRiANe+azVNnVjJ2fIrEDCW0oV6Fo6lZ4g7otvdzTHy7JBeg==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
         "@fortawesome/free-solid-svg-icons": "^6.2.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@gemeente-denhaag/button": "0.2.3-alpha.205",
-        "@gemeente-denhaag/design-tokens-components": "0.2.3-alpha.222",
-        "@gemeente-denhaag/divider": "0.2.3-alpha.205",
         "@gemeente-denhaag/form-field": "0.1.1-alpha.98",
-        "@gemeente-denhaag/formcontrollabel": "0.2.3-alpha.222",
-        "@gemeente-denhaag/link": "0.2.3-alpha.205",
+        "@gemeente-denhaag/icons": "^0.2.3-alpha.317",
         "@gemeente-denhaag/process-steps": "0.1.0-alpha.51",
         "@gemeente-denhaag/sidenav": "0.1.0-alpha.40",
-        "@gemeente-denhaag/stylesprovider": "0.1.1-alpha.222",
-        "@gemeente-denhaag/table": "0.1.1-alpha.123",
         "@gemeente-denhaag/textarea": "0.1.1-alpha.95",
         "@gemeente-denhaag/textfield": "0.2.3-alpha.205",
-        "@gemeente-denhaag/typography": "0.2.3-alpha.205",
+        "@utrecht/component-library-react": "^1.0.0-alpha.319",
         "clsx": "^1.1.1",
         "gatsby": "^4.11.1",
-        "react": "^17.0.1",
+        "react": "^18.2.0",
         "react-datepicker": "^4.10.0",
         "react-hook-form": "7.29.0",
+        "react-paginate": "^8.2.0",
         "react-select": "5.3.2",
         "react-tooltip": "^4.2.21"
       }
@@ -1894,17 +1899,6 @@
       "peerDependencies": {
         "@fortawesome/fontawesome-svg-core": "~1 || ~6",
         "react": ">=16.3"
-      }
-    },
-    "node_modules/@conduction/components/node_modules/@gemeente-denhaag/basedatadisplayprops": {
-      "version": "0.2.3-alpha.205",
-      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/basedatadisplayprops/-/basedatadisplayprops-0.2.3-alpha.205.tgz",
-      "integrity": "sha512-/MTUJuWBgHU8j6gNugMrxULJSCYqF7C6dcIxE/TEp0qYTWyGswLPeFkhmL/mRZLenPVK91yfFNgLqhzlhTdqtw==",
-      "dependencies": {
-        "@gemeente-denhaag/baseprops": "0.2.3-alpha.205"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0"
       }
     },
     "node_modules/@conduction/components/node_modules/@gemeente-denhaag/baseprops": {
@@ -1926,36 +1920,12 @@
         "react": "^17.0.0"
       }
     },
-    "node_modules/@conduction/components/node_modules/@gemeente-denhaag/divider": {
-      "version": "0.2.3-alpha.205",
-      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/divider/-/divider-0.2.3-alpha.205.tgz",
-      "integrity": "sha512-tdypV1Qy3MAuhYRV2yosgGVctRIEmdmZeRcgYnUM0i8JmUrJpCtRmydmnIDwYsULiD5Nc3WlquR5nGsOUy2T4Q==",
-      "dependencies": {
-        "@gemeente-denhaag/basedatadisplayprops": "0.2.3-alpha.205",
-        "@material-ui/core": "4.12.3"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0"
-      }
-    },
     "node_modules/@conduction/components/node_modules/@gemeente-denhaag/icons": {
-      "version": "0.2.3-alpha.205",
-      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/icons/-/icons-0.2.3-alpha.205.tgz",
-      "integrity": "sha512-SQpiE7iuIpD3zvOZ48mY+skb7RaIr0TkeSoxIz3X5lTr+VjQf7OFKpFTECSnPrpphOQ4CQ6hSAtM/CwnEzWzXQ==",
+      "version": "0.2.3-alpha.324",
+      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/icons/-/icons-0.2.3-alpha.324.tgz",
+      "integrity": "sha512-sVPDFFbgqEPw4e9k5fkjQCVBakyMNq2aJs2nuauRQfLxz5HrwnJN9wieG+4l/NAeUxSURMSDoDsNaJf6bODEpA==",
       "peerDependencies": {
-        "react": "^17.0.0"
-      }
-    },
-    "node_modules/@conduction/components/node_modules/@gemeente-denhaag/link": {
-      "version": "0.2.3-alpha.205",
-      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/link/-/link-0.2.3-alpha.205.tgz",
-      "integrity": "sha512-wVT7YMLrJLKV9Ckcy2ajx/fNneAFy2TNspXjG9nriYL/EjMe/jXPziJ1LtP1YJZFoJsZN+gxn/UJK3U1Vo5R2w==",
-      "dependencies": {
-        "@gemeente-denhaag/baseprops": "0.2.3-alpha.205",
-        "@gemeente-denhaag/icons": "0.2.3-alpha.205"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0"
+        "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@conduction/components/node_modules/@gemeente-denhaag/textfield": {
@@ -1969,52 +1939,12 @@
         "react": "^17.0.0"
       }
     },
-    "node_modules/@conduction/components/node_modules/@gemeente-denhaag/typography": {
+    "node_modules/@conduction/components/node_modules/@gemeente-denhaag/textfield/node_modules/@gemeente-denhaag/icons": {
       "version": "0.2.3-alpha.205",
-      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/typography/-/typography-0.2.3-alpha.205.tgz",
-      "integrity": "sha512-GdO7MM+kkotWJdyNMiGP/B4qK11oOOZzsU/mobXY/W/RisWh8JotBaRpRXn/N8MksRwaAiMzKHLuo4wtOPthDQ==",
-      "dependencies": {
-        "@gemeente-denhaag/basedatadisplayprops": "0.2.3-alpha.205"
-      },
+      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/icons/-/icons-0.2.3-alpha.205.tgz",
+      "integrity": "sha512-SQpiE7iuIpD3zvOZ48mY+skb7RaIr0TkeSoxIz3X5lTr+VjQf7OFKpFTECSnPrpphOQ4CQ6hSAtM/CwnEzWzXQ==",
       "peerDependencies": {
         "react": "^17.0.0"
-      }
-    },
-    "node_modules/@conduction/components/node_modules/@material-ui/core": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.3.tgz",
-      "integrity": "sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==",
-      "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.11.4",
-        "@material-ui/system": "^4.12.1",
-        "@material-ui/types": "5.1.0",
-        "@material-ui/utils": "^4.11.2",
-        "@types/react-transition-group": "^4.2.0",
-        "clsx": "^1.0.4",
-        "hoist-non-react-statics": "^3.3.2",
-        "popper.js": "1.16.1-lts",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0 || ^17.0.0",
-        "react-transition-group": "^4.4.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/material-ui"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -2276,6 +2206,17 @@
         "react": "^17.0.0"
       }
     },
+    "node_modules/@gemeente-denhaag/alert/node_modules/@gemeente-denhaag/button": {
+      "version": "0.2.3-alpha.222",
+      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/button/-/button-0.2.3-alpha.222.tgz",
+      "integrity": "sha512-T7zF20zA49vCa5l4XQLRaEqkV1XDgRLMnA9PcOk+2TEDFyxW8YphEuiWrqodBvXO2dZXsMesnwqmMsrNWHGthw==",
+      "dependencies": {
+        "@gemeente-denhaag/baseprops": "0.2.3-alpha.222"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
     "node_modules/@gemeente-denhaag/avatar": {
       "version": "0.2.3-alpha.222",
       "license": "EUPL-1.2",
@@ -2315,13 +2256,22 @@
       }
     },
     "node_modules/@gemeente-denhaag/button": {
-      "version": "0.2.3-alpha.222",
-      "license": "EUPL-1.2",
+      "version": "0.2.3-alpha.324",
+      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/button/-/button-0.2.3-alpha.324.tgz",
+      "integrity": "sha512-1HOuABsT7KY/3yo/DyxLrcUl7pwnB4y9VD48vjge0PgeQfY+3KpmN2lURjwHgFKJt73AZisaZ+zOmZ4t5dBvRQ==",
       "dependencies": {
-        "@gemeente-denhaag/baseprops": "0.2.3-alpha.222"
+        "@gemeente-denhaag/baseprops": "0.2.3-alpha.324"
       },
       "peerDependencies": {
-        "react": "^17.0.0"
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@gemeente-denhaag/button/node_modules/@gemeente-denhaag/baseprops": {
+      "version": "0.2.3-alpha.324",
+      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/baseprops/-/baseprops-0.2.3-alpha.324.tgz",
+      "integrity": "sha512-Rw6CdyURJB6BP4FdqjaieE+QQ83F4QlxG6bpv8iPR09vH9fxETyc+hbELPVVsK2le7PrNtkzWul8g9Wo5PEc9A==",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@gemeente-denhaag/card": {
@@ -2376,6 +2326,17 @@
         "@gemeente-denhaag/textfield": "0.2.3-alpha.222",
         "@gemeente-denhaag/timeline": "0.2.3-alpha.222",
         "@gemeente-denhaag/typography": "0.2.3-alpha.222"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0"
+      }
+    },
+    "node_modules/@gemeente-denhaag/components-react/node_modules/@gemeente-denhaag/button": {
+      "version": "0.2.3-alpha.222",
+      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/button/-/button-0.2.3-alpha.222.tgz",
+      "integrity": "sha512-T7zF20zA49vCa5l4XQLRaEqkV1XDgRLMnA9PcOk+2TEDFyxW8YphEuiWrqodBvXO2dZXsMesnwqmMsrNWHGthw==",
+      "dependencies": {
+        "@gemeente-denhaag/baseprops": "0.2.3-alpha.222"
       },
       "peerDependencies": {
         "react": "^17.0.0"
@@ -2583,6 +2544,33 @@
       },
       "peerDependencies": {
         "react": "^17.0.0"
+      }
+    },
+    "node_modules/@gemeente-denhaag/tab/node_modules/@material-ui/lab": {
+      "version": "4.11.3-deprecations.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.11.3-deprecations.1.tgz",
+      "integrity": "sha512-mP53Wh3jKzPcZbvnY+hLWQmfEq8JmUP1SrR1r8S+jxMymC20/SLxMVVLb4h4pmZ0+ga232JegG0XypQ/r9I5TA==",
+      "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
+      "dependencies": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@material-ui/core": "^4.11.3-deprecations.1",
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@gemeente-denhaag/table": {
@@ -3196,11 +3184,13 @@
       }
     },
     "node_modules/@material-ui/lab": {
-      "version": "4.11.3-deprecations.1",
-      "license": "MIT",
+      "version": "4.0.0-alpha.61",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.61.tgz",
+      "integrity": "sha512-rSzm+XKiNUjKegj8bzt5+pygZeckNLOr+IjykH8sYdVk7dE9y2ZuUSofiMV2bJk3qU+JHwexmw+q0RyNZB9ugg==",
+      "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
       "dependencies": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.11.2",
+        "@material-ui/utils": "^4.11.3",
         "clsx": "^1.0.4",
         "prop-types": "^15.7.2",
         "react-is": "^16.8.0 || ^17.0.0"
@@ -3209,7 +3199,7 @@
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "@material-ui/core": "^4.11.3-deprecations.1",
+        "@material-ui/core": "^4.12.1",
         "@types/react": "^16.8.6 || ^17.0.0",
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
@@ -4380,11 +4370,12 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.17",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
+      "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@types/react": "^17"
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-helmet": {
@@ -4642,6 +4633,35 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@utrecht/component-library-react": {
+      "version": "1.0.0-alpha.360",
+      "resolved": "https://registry.npmjs.org/@utrecht/component-library-react/-/component-library-react-1.0.0-alpha.360.tgz",
+      "integrity": "sha512-3k91TDwQTMwgHm1npg51FPz0R41Qj2+J3wqc0F9Ge9aESVXlLDVi+bG5hay0TjMXtVAEV+KgMBlCMYRosjKrMQ==",
+      "dependencies": {
+        "clsx": "1.2.1",
+        "date-fns": "2.30.0",
+        "lodash.chunk": "4.2.0"
+      },
+      "peerDependencies": {
+        "react": "18",
+        "react-dom": "18"
+      }
+    },
+    "node_modules/@utrecht/component-library-react/node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/@vercel/webpack-asset-relocator-loader": {
@@ -5139,33 +5159,6 @@
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "license": "Apache-2.0"
-    },
-    "node_modules/babel-eslint": {
-      "version": "10.1.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": ">= 4.12.1"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/babel-loader": {
       "version": "8.2.5",
@@ -6021,8 +6014,9 @@
       }
     },
     "node_modules/clsx": {
-      "version": "1.1.1",
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "engines": {
         "node": ">=6"
       }
@@ -10541,6 +10535,11 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "node_modules/lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w=="
+    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "license": "MIT"
@@ -10916,11 +10915,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/monaco-editor": {
-      "version": "0.36.1",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -12693,11 +12687,11 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "license": "MIT",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -12830,15 +12824,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
-      "license": "MIT",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-dropzone": {
@@ -12919,11 +12913,6 @@
         "react-dom": ">=16"
       }
     },
-    "node_modules/react-hot-toast/node_modules/csstype": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/react-hot-toast/node_modules/goober": {
       "version": "2.1.11",
       "license": "MIT",
@@ -12961,8 +12950,9 @@
       "license": "MIT"
     },
     "node_modules/react-loading-skeleton": {
-      "version": "3.1.0",
-      "license": "MIT",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.0.0.tgz",
+      "integrity": "sha512-bwrYcwBf8Vu0xlpD66+PESonNdX87W/BCmGrH19hSXYt64zVNn8WGVcnC+6H5My95+8/nvhZ4naKq38VQ2qbMw==",
       "peerDependencies": {
         "react": ">=16.8.0"
       }
@@ -12991,8 +12981,9 @@
       }
     },
     "node_modules/react-paginate": {
-      "version": "8.1.4",
-      "license": "MIT",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-8.2.0.tgz",
+      "integrity": "sha512-sJCz1PW+9PNIjUSn919nlcRVuleN2YPoFBOvL+6TPgrH/3lwphqiSOgdrLafLdyLDxsgK+oSgviqacF4hxsDIw==",
       "dependencies": {
         "prop-types": "^15"
       },
@@ -13510,11 +13501,11 @@
       "license": "MIT"
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "license": "MIT",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/schema-utils": {
@@ -14694,6 +14685,7 @@
     },
     "node_modules/typescript": {
       "version": "4.7.3",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -16570,9 +16562,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.20.13",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
+      "integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
       "requires": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+          "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+        }
       }
     },
     "@babel/runtime-corejs3": {
@@ -16628,31 +16629,27 @@
       "version": "0.5.4"
     },
     "@conduction/components": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/@conduction/components/-/components-2.1.27.tgz",
-      "integrity": "sha512-e/l5b44BNJp1r+rTkZhvVjEuaF/+3yNpHl0ToLr/bZsn57Brxs9imaDXSkAlrRUXRSBPEfXqtifwmhzJk1Davg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@conduction/components/-/components-2.2.0.tgz",
+      "integrity": "sha512-bAJHU3fn+e3lH2kZXAfHJOhdITVbV8tyqIBU72YRiANe+azVNnVjJ2fIrEDCW0oV6Fo6lZ4g7otvdzTHy7JBeg==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
         "@fortawesome/free-solid-svg-icons": "^6.2.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@gemeente-denhaag/button": "0.2.3-alpha.205",
-        "@gemeente-denhaag/design-tokens-components": "0.2.3-alpha.222",
-        "@gemeente-denhaag/divider": "0.2.3-alpha.205",
         "@gemeente-denhaag/form-field": "0.1.1-alpha.98",
-        "@gemeente-denhaag/formcontrollabel": "0.2.3-alpha.222",
-        "@gemeente-denhaag/link": "0.2.3-alpha.205",
+        "@gemeente-denhaag/icons": "^0.2.3-alpha.317",
         "@gemeente-denhaag/process-steps": "0.1.0-alpha.51",
         "@gemeente-denhaag/sidenav": "0.1.0-alpha.40",
-        "@gemeente-denhaag/stylesprovider": "0.1.1-alpha.222",
-        "@gemeente-denhaag/table": "0.1.1-alpha.123",
         "@gemeente-denhaag/textarea": "0.1.1-alpha.95",
         "@gemeente-denhaag/textfield": "0.2.3-alpha.205",
-        "@gemeente-denhaag/typography": "0.2.3-alpha.205",
+        "@utrecht/component-library-react": "^1.0.0-alpha.319",
         "clsx": "^1.1.1",
         "gatsby": "^4.11.1",
-        "react": "^17.0.1",
+        "react": "^18.2.0",
         "react-datepicker": "^4.10.0",
         "react-hook-form": "7.29.0",
+        "react-paginate": "^8.2.0",
         "react-select": "5.3.2",
         "react-tooltip": "^4.2.21"
       },
@@ -16663,19 +16660,10 @@
             "prop-types": "^15.8.1"
           }
         },
-        "@gemeente-denhaag/basedatadisplayprops": {
-          "version": "0.2.3-alpha.205",
-          "resolved": "https://registry.npmjs.org/@gemeente-denhaag/basedatadisplayprops/-/basedatadisplayprops-0.2.3-alpha.205.tgz",
-          "integrity": "sha512-/MTUJuWBgHU8j6gNugMrxULJSCYqF7C6dcIxE/TEp0qYTWyGswLPeFkhmL/mRZLenPVK91yfFNgLqhzlhTdqtw==",
-          "requires": {
-            "@gemeente-denhaag/baseprops": "0.2.3-alpha.205"
-          }
-        },
         "@gemeente-denhaag/baseprops": {
           "version": "0.2.3-alpha.205",
           "resolved": "https://registry.npmjs.org/@gemeente-denhaag/baseprops/-/baseprops-0.2.3-alpha.205.tgz",
-          "integrity": "sha512-RZGOwSEpYJlrNFNppP6Ztl/44ld1HxnVk931D02G1+55qiQFh/ZGu+p7cH4eDO9tEtHuITIH3F5sQnhAG0hWiw==",
-          "requires": {}
+          "integrity": "sha512-RZGOwSEpYJlrNFNppP6Ztl/44ld1HxnVk931D02G1+55qiQFh/ZGu+p7cH4eDO9tEtHuITIH3F5sQnhAG0hWiw=="
         },
         "@gemeente-denhaag/button": {
           "version": "0.2.3-alpha.205",
@@ -16685,29 +16673,10 @@
             "@gemeente-denhaag/baseprops": "0.2.3-alpha.205"
           }
         },
-        "@gemeente-denhaag/divider": {
-          "version": "0.2.3-alpha.205",
-          "resolved": "https://registry.npmjs.org/@gemeente-denhaag/divider/-/divider-0.2.3-alpha.205.tgz",
-          "integrity": "sha512-tdypV1Qy3MAuhYRV2yosgGVctRIEmdmZeRcgYnUM0i8JmUrJpCtRmydmnIDwYsULiD5Nc3WlquR5nGsOUy2T4Q==",
-          "requires": {
-            "@gemeente-denhaag/basedatadisplayprops": "0.2.3-alpha.205",
-            "@material-ui/core": "4.12.3"
-          }
-        },
         "@gemeente-denhaag/icons": {
-          "version": "0.2.3-alpha.205",
-          "resolved": "https://registry.npmjs.org/@gemeente-denhaag/icons/-/icons-0.2.3-alpha.205.tgz",
-          "integrity": "sha512-SQpiE7iuIpD3zvOZ48mY+skb7RaIr0TkeSoxIz3X5lTr+VjQf7OFKpFTECSnPrpphOQ4CQ6hSAtM/CwnEzWzXQ==",
-          "requires": {}
-        },
-        "@gemeente-denhaag/link": {
-          "version": "0.2.3-alpha.205",
-          "resolved": "https://registry.npmjs.org/@gemeente-denhaag/link/-/link-0.2.3-alpha.205.tgz",
-          "integrity": "sha512-wVT7YMLrJLKV9Ckcy2ajx/fNneAFy2TNspXjG9nriYL/EjMe/jXPziJ1LtP1YJZFoJsZN+gxn/UJK3U1Vo5R2w==",
-          "requires": {
-            "@gemeente-denhaag/baseprops": "0.2.3-alpha.205",
-            "@gemeente-denhaag/icons": "0.2.3-alpha.205"
-          }
+          "version": "0.2.3-alpha.324",
+          "resolved": "https://registry.npmjs.org/@gemeente-denhaag/icons/-/icons-0.2.3-alpha.324.tgz",
+          "integrity": "sha512-sVPDFFbgqEPw4e9k5fkjQCVBakyMNq2aJs2nuauRQfLxz5HrwnJN9wieG+4l/NAeUxSURMSDoDsNaJf6bODEpA=="
         },
         "@gemeente-denhaag/textfield": {
           "version": "0.2.3-alpha.205",
@@ -16715,33 +16684,13 @@
           "integrity": "sha512-zG1fYxAQ1hOVTbcyVMaPZRjFGsPcNhoRfOigXZcvmnnzXQLKQsUgV69nHDc/0VyaqSCv09wXB9DLUKJLg0XjAA==",
           "requires": {
             "@gemeente-denhaag/icons": "0.2.3-alpha.205"
-          }
-        },
-        "@gemeente-denhaag/typography": {
-          "version": "0.2.3-alpha.205",
-          "resolved": "https://registry.npmjs.org/@gemeente-denhaag/typography/-/typography-0.2.3-alpha.205.tgz",
-          "integrity": "sha512-GdO7MM+kkotWJdyNMiGP/B4qK11oOOZzsU/mobXY/W/RisWh8JotBaRpRXn/N8MksRwaAiMzKHLuo4wtOPthDQ==",
-          "requires": {
-            "@gemeente-denhaag/basedatadisplayprops": "0.2.3-alpha.205"
-          }
-        },
-        "@material-ui/core": {
-          "version": "4.12.3",
-          "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.3.tgz",
-          "integrity": "sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "@material-ui/styles": "^4.11.4",
-            "@material-ui/system": "^4.12.1",
-            "@material-ui/types": "5.1.0",
-            "@material-ui/utils": "^4.11.2",
-            "@types/react-transition-group": "^4.2.0",
-            "clsx": "^1.0.4",
-            "hoist-non-react-statics": "^3.3.2",
-            "popper.js": "1.16.1-lts",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.0 || ^17.0.0",
-            "react-transition-group": "^4.4.0"
+          },
+          "dependencies": {
+            "@gemeente-denhaag/icons": {
+              "version": "0.2.3-alpha.205",
+              "resolved": "https://registry.npmjs.org/@gemeente-denhaag/icons/-/icons-0.2.3-alpha.205.tgz",
+              "integrity": "sha512-SQpiE7iuIpD3zvOZ48mY+skb7RaIr0TkeSoxIz3X5lTr+VjQf7OFKpFTECSnPrpphOQ4CQ6hSAtM/CwnEzWzXQ=="
+            }
           }
         }
       }
@@ -16824,8 +16773,7 @@
       "version": "0.8.1"
     },
     "@emotion/use-insertion-effect-with-fallbacks": {
-      "version": "1.0.1",
-      "requires": {}
+      "version": "1.0.1"
     },
     "@emotion/utils": {
       "version": "1.2.1"
@@ -16921,6 +16869,16 @@
         "@gemeente-denhaag/iconbutton": "0.2.3-alpha.222",
         "@gemeente-denhaag/icons": "0.2.3-alpha.222",
         "@gemeente-denhaag/typography": "0.2.3-alpha.222"
+      },
+      "dependencies": {
+        "@gemeente-denhaag/button": {
+          "version": "0.2.3-alpha.222",
+          "resolved": "https://registry.npmjs.org/@gemeente-denhaag/button/-/button-0.2.3-alpha.222.tgz",
+          "integrity": "sha512-T7zF20zA49vCa5l4XQLRaEqkV1XDgRLMnA9PcOk+2TEDFyxW8YphEuiWrqodBvXO2dZXsMesnwqmMsrNWHGthw==",
+          "requires": {
+            "@gemeente-denhaag/baseprops": "0.2.3-alpha.222"
+          }
+        }
       }
     },
     "@gemeente-denhaag/avatar": {
@@ -16943,13 +16901,21 @@
       }
     },
     "@gemeente-denhaag/baseprops": {
-      "version": "0.2.3-alpha.222",
-      "requires": {}
+      "version": "0.2.3-alpha.222"
     },
     "@gemeente-denhaag/button": {
-      "version": "0.2.3-alpha.222",
+      "version": "0.2.3-alpha.324",
+      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/button/-/button-0.2.3-alpha.324.tgz",
+      "integrity": "sha512-1HOuABsT7KY/3yo/DyxLrcUl7pwnB4y9VD48vjge0PgeQfY+3KpmN2lURjwHgFKJt73AZisaZ+zOmZ4t5dBvRQ==",
       "requires": {
-        "@gemeente-denhaag/baseprops": "0.2.3-alpha.222"
+        "@gemeente-denhaag/baseprops": "0.2.3-alpha.324"
+      },
+      "dependencies": {
+        "@gemeente-denhaag/baseprops": {
+          "version": "0.2.3-alpha.324",
+          "resolved": "https://registry.npmjs.org/@gemeente-denhaag/baseprops/-/baseprops-0.2.3-alpha.324.tgz",
+          "integrity": "sha512-Rw6CdyURJB6BP4FdqjaieE+QQ83F4QlxG6bpv8iPR09vH9fxETyc+hbELPVVsK2le7PrNtkzWul8g9Wo5PEc9A=="
+        }
       }
     },
     "@gemeente-denhaag/card": {
@@ -16995,6 +16961,16 @@
         "@gemeente-denhaag/textfield": "0.2.3-alpha.222",
         "@gemeente-denhaag/timeline": "0.2.3-alpha.222",
         "@gemeente-denhaag/typography": "0.2.3-alpha.222"
+      },
+      "dependencies": {
+        "@gemeente-denhaag/button": {
+          "version": "0.2.3-alpha.222",
+          "resolved": "https://registry.npmjs.org/@gemeente-denhaag/button/-/button-0.2.3-alpha.222.tgz",
+          "integrity": "sha512-T7zF20zA49vCa5l4XQLRaEqkV1XDgRLMnA9PcOk+2TEDFyxW8YphEuiWrqodBvXO2dZXsMesnwqmMsrNWHGthw==",
+          "requires": {
+            "@gemeente-denhaag/baseprops": "0.2.3-alpha.222"
+          }
+        }
       }
     },
     "@gemeente-denhaag/datepicker": {
@@ -17021,8 +16997,7 @@
       }
     },
     "@gemeente-denhaag/form-field": {
-      "version": "0.1.1-alpha.98",
-      "requires": {}
+      "version": "0.1.1-alpha.98"
     },
     "@gemeente-denhaag/formcontrol": {
       "version": "0.2.3-alpha.222",
@@ -17031,8 +17006,7 @@
       }
     },
     "@gemeente-denhaag/formcontrollabel": {
-      "version": "0.2.3-alpha.222",
-      "requires": {}
+      "version": "0.2.3-alpha.222"
     },
     "@gemeente-denhaag/formgroup": {
       "version": "0.2.3-alpha.222",
@@ -17050,8 +17024,7 @@
       }
     },
     "@gemeente-denhaag/icons": {
-      "version": "0.2.3-alpha.222",
-      "requires": {}
+      "version": "0.2.3-alpha.222"
     },
     "@gemeente-denhaag/inputlabel": {
       "version": "0.2.3-alpha.222",
@@ -17090,8 +17063,7 @@
       }
     },
     "@gemeente-denhaag/radio": {
-      "version": "0.2.3-alpha.222",
-      "requires": {}
+      "version": "0.2.3-alpha.222"
     },
     "@gemeente-denhaag/select": {
       "version": "0.2.3-alpha.222",
@@ -17101,8 +17073,7 @@
       }
     },
     "@gemeente-denhaag/sidenav": {
-      "version": "0.1.0-alpha.40",
-      "requires": {}
+      "version": "0.1.0-alpha.40"
     },
     "@gemeente-denhaag/stylesprovider": {
       "version": "0.1.1-alpha.222",
@@ -17123,11 +17094,24 @@
         "@gemeente-denhaag/baseprops": "0.2.3-alpha.222",
         "@material-ui/core": "4.12.4",
         "@material-ui/lab": "4.11.3-deprecations.1"
+      },
+      "dependencies": {
+        "@material-ui/lab": {
+          "version": "4.11.3-deprecations.1",
+          "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.11.3-deprecations.1.tgz",
+          "integrity": "sha512-mP53Wh3jKzPcZbvnY+hLWQmfEq8JmUP1SrR1r8S+jxMymC20/SLxMVVLb4h4pmZ0+ga232JegG0XypQ/r9I5TA==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@material-ui/utils": "^4.11.2",
+            "clsx": "^1.0.4",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0 || ^17.0.0"
+          }
+        }
       }
     },
     "@gemeente-denhaag/table": {
-      "version": "0.1.1-alpha.123",
-      "requires": {}
+      "version": "0.1.1-alpha.123"
     },
     "@gemeente-denhaag/textarea": {
       "version": "0.1.1-alpha.95",
@@ -17470,8 +17454,7 @@
       }
     },
     "@graphql-typed-document-node/core": {
-      "version": "3.1.1",
-      "requires": {}
+      "version": "3.1.1"
     },
     "@hapi/hoek": {
       "version": "9.3.0"
@@ -17575,10 +17558,12 @@
       }
     },
     "@material-ui/lab": {
-      "version": "4.11.3-deprecations.1",
+      "version": "4.0.0-alpha.61",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.61.tgz",
+      "integrity": "sha512-rSzm+XKiNUjKegj8bzt5+pygZeckNLOr+IjykH8sYdVk7dE9y2ZuUSofiMV2bJk3qU+JHwexmw+q0RyNZB9ugg==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.11.2",
+        "@material-ui/utils": "^4.11.3",
         "clsx": "^1.0.4",
         "prop-types": "^15.7.2",
         "react-is": "^16.8.0 || ^17.0.0"
@@ -17615,8 +17600,7 @@
       }
     },
     "@material-ui/types": {
-      "version": "5.1.0",
-      "requires": {}
+      "version": "5.1.0"
     },
     "@material-ui/utils": {
       "version": "4.11.3",
@@ -18243,10 +18227,12 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.17",
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
+      "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
       "dev": true,
       "requires": {
-        "@types/react": "^17"
+        "@types/react": "*"
       }
     },
     "@types/react-helmet": {
@@ -18388,6 +18374,26 @@
         "eslint-visitor-keys": "^2.0.0"
       }
     },
+    "@utrecht/component-library-react": {
+      "version": "1.0.0-alpha.360",
+      "resolved": "https://registry.npmjs.org/@utrecht/component-library-react/-/component-library-react-1.0.0-alpha.360.tgz",
+      "integrity": "sha512-3k91TDwQTMwgHm1npg51FPz0R41Qj2+J3wqc0F9Ge9aESVXlLDVi+bG5hay0TjMXtVAEV+KgMBlCMYRosjKrMQ==",
+      "requires": {
+        "clsx": "1.2.1",
+        "date-fns": "2.30.0",
+        "lodash.chunk": "4.2.0"
+      },
+      "dependencies": {
+        "date-fns": {
+          "version": "2.30.0",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+          "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+          "requires": {
+            "@babel/runtime": "^7.21.0"
+          }
+        }
+      }
+    },
     "@vercel/webpack-asset-relocator-loader": {
       "version": "1.7.2"
     },
@@ -18512,8 +18518,7 @@
       "version": "7.4.1"
     },
     "acorn-jsx": {
-      "version": "5.3.2",
-      "requires": {}
+      "version": "5.3.2"
     },
     "acorn-loose": {
       "version": "8.3.0",
@@ -18542,8 +18547,7 @@
       }
     },
     "ajv-keywords": {
-      "version": "3.5.2",
-      "requires": {}
+      "version": "3.5.2"
     },
     "anser": {
       "version": "2.1.1"
@@ -18692,24 +18696,6 @@
     },
     "axobject-query": {
       "version": "2.2.0"
-    },
-    "babel-eslint": {
-      "version": "10.1.0",
-      "peer": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "peer": true
-        }
-      }
     },
     "babel-loader": {
       "version": "8.2.5",
@@ -19262,7 +19248,9 @@
       }
     },
     "clsx": {
-      "version": "1.1.1"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "color": {
       "version": "4.2.3",
@@ -19471,8 +19459,7 @@
       "version": "2.0.0"
     },
     "css-declaration-sorter": {
-      "version": "6.3.0",
-      "requires": {}
+      "version": "6.3.0"
     },
     "css-loader": {
       "version": "5.2.7",
@@ -19608,8 +19595,7 @@
       }
     },
     "cssnano-utils": {
-      "version": "3.1.0",
-      "requires": {}
+      "version": "3.1.0"
     },
     "csso": {
       "version": "4.2.0",
@@ -20259,8 +20245,7 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "4.6.0",
-      "requires": {}
+      "version": "4.6.0"
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -21180,8 +21165,7 @@
       }
     },
     "gatsby-script": {
-      "version": "1.10.0",
-      "requires": {}
+      "version": "1.10.0"
     },
     "gatsby-sharp": {
       "version": "0.19.0",
@@ -21393,8 +21377,7 @@
       }
     },
     "graphql-type-json": {
-      "version": "0.3.2",
-      "requires": {}
+      "version": "0.3.2"
     },
     "gzip-size": {
       "version": "6.0.0",
@@ -21545,8 +21528,7 @@
       }
     },
     "icss-utils": {
-      "version": "5.1.0",
-      "requires": {}
+      "version": "5.1.0"
     },
     "identity-obj-proxy": {
       "version": "3.0.0",
@@ -22108,6 +22090,11 @@
     "lodash": {
       "version": "4.17.21"
     },
+    "lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w=="
+    },
     "lodash.clonedeep": {
       "version": "4.5.0"
     },
@@ -22342,10 +22329,6 @@
     },
     "moment": {
       "version": "2.29.4"
-    },
-    "monaco-editor": {
-      "version": "0.36.1",
-      "peer": true
     },
     "ms": {
       "version": "2.1.3"
@@ -22984,24 +22967,19 @@
       }
     },
     "postcss-discard-comments": {
-      "version": "5.1.2",
-      "requires": {}
+      "version": "5.1.2"
     },
     "postcss-discard-duplicates": {
-      "version": "5.1.0",
-      "requires": {}
+      "version": "5.1.0"
     },
     "postcss-discard-empty": {
-      "version": "5.1.1",
-      "requires": {}
+      "version": "5.1.1"
     },
     "postcss-discard-overridden": {
-      "version": "5.1.0",
-      "requires": {}
+      "version": "5.1.0"
     },
     "postcss-flexbugs-fixes": {
-      "version": "5.0.2",
-      "requires": {}
+      "version": "5.0.2"
     },
     "postcss-loader": {
       "version": "5.3.0",
@@ -23056,8 +23034,7 @@
       }
     },
     "postcss-modules-extract-imports": {
-      "version": "3.0.0",
-      "requires": {}
+      "version": "3.0.0"
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -23080,8 +23057,7 @@
       }
     },
     "postcss-normalize-charset": {
-      "version": "5.1.0",
-      "requires": {}
+      "version": "5.1.0"
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -23351,15 +23327,15 @@
       }
     },
     "react": {
-      "version": "17.0.2",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-collapsible": {
-      "version": "2.10.0",
-      "requires": {}
+      "version": "2.10.0"
     },
     "react-datepicker": {
       "version": "4.11.0",
@@ -23437,11 +23413,12 @@
       }
     },
     "react-dom": {
-      "version": "17.0.2",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.0"
       }
     },
     "react-dropzone": {
@@ -23476,8 +23453,7 @@
       }
     },
     "react-hook-form": {
-      "version": "7.29.0",
-      "requires": {}
+      "version": "7.29.0"
     },
     "react-hot-toast": {
       "version": "2.4.0",
@@ -23485,13 +23461,8 @@
         "goober": "^2.1.10"
       },
       "dependencies": {
-        "csstype": {
-          "version": "3.1.1",
-          "peer": true
-        },
         "goober": {
-          "version": "2.1.11",
-          "requires": {}
+          "version": "2.1.11"
         }
       }
     },
@@ -23510,8 +23481,9 @@
       "version": "3.0.4"
     },
     "react-loading-skeleton": {
-      "version": "3.1.0",
-      "requires": {}
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.0.0.tgz",
+      "integrity": "sha512-bwrYcwBf8Vu0xlpD66+PESonNdX87W/BCmGrH19hSXYt64zVNn8WGVcnC+6H5My95+8/nvhZ4naKq38VQ2qbMw=="
     },
     "react-minimal-pie-chart": {
       "version": "8.4.0",
@@ -23520,11 +23492,12 @@
       }
     },
     "react-onclickoutside": {
-      "version": "6.13.0",
-      "requires": {}
+      "version": "6.13.0"
     },
     "react-paginate": {
-      "version": "8.1.4",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-8.2.0.tgz",
+      "integrity": "sha512-sJCz1PW+9PNIjUSn919nlcRVuleN2YPoFBOvL+6TPgrH/3lwphqiSOgdrLafLdyLDxsgK+oSgviqacF4hxsDIw==",
       "requires": {
         "prop-types": "^15"
       }
@@ -23560,8 +23533,7 @@
       }
     },
     "react-side-effect": {
-      "version": "2.1.1",
-      "requires": {}
+      "version": "2.1.1"
     },
     "react-tooltip": {
       "version": "4.5.1",
@@ -23642,8 +23614,7 @@
       }
     },
     "redux-thunk": {
-      "version": "2.4.1",
-      "requires": {}
+      "version": "2.4.1"
     },
     "regenerate": {
       "version": "1.4.2"
@@ -23830,10 +23801,11 @@
       "version": "2.1.2"
     },
     "scheduler": {
-      "version": "0.20.2",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "schema-utils": {
@@ -24565,7 +24537,8 @@
       }
     },
     "typescript": {
-      "version": "4.7.3"
+      "version": "4.7.3",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.33"
@@ -24778,8 +24751,7 @@
           "version": "8.7.1"
         },
         "acorn-import-assertions": {
-          "version": "1.8.0",
-          "requires": {}
+          "version": "1.8.0"
         },
         "schema-utils": {
           "version": "3.1.1",
@@ -24905,8 +24877,7 @@
       }
     },
     "ws": {
-      "version": "8.2.3",
-      "requires": {}
+      "version": "8.2.3"
     },
     "xdg-basedir": {
       "version": "4.0.0"

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -4,9 +4,7 @@
   "private": true,
   "description": "Gatsby Skeleton Application",
   "author": "Conduction B.V.",
-  "keywords": [
-    "gatsby"
-  ],
+  "keywords": ["gatsby"],
   "scripts": {
     "develop": "gatsby develop",
     "start": "gatsby develop",
@@ -16,10 +14,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@conduction/components": "2.1.27",
+    "@conduction/components": "2.2.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
+    "@gemeente-denhaag/button": "^0.2.3-alpha.323",
     "@gemeente-denhaag/components-react": "^0.1.1-alpha.143",
     "@gemeente-denhaag/design-tokens-components": "^0.2.3-alpha.178",
     "@gemeente-denhaag/form-field": "^0.1.1-alpha.67",
@@ -27,6 +26,8 @@
     "@gemeente-denhaag/sidenav": "^0.1.0-alpha.1",
     "@gemeente-denhaag/table": "^0.1.1-alpha.87",
     "@gemeente-denhaag/textarea": "^0.1.1-alpha.65",
+    "@material-ui/core": "^4.12.4",
+    "@material-ui/lab": "^4.0.0-alpha.61",
     "@monaco-editor/react": "^4.4.6",
     "@opengemeenten/iconset-react": "^1.0.1",
     "axios": "^0.25.0",
@@ -40,16 +41,16 @@
     "i18next": "^21.6.16",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
-    "react": "^17.0.1",
+    "react": "^18.2.0",
     "react-collapsible": "^2.10.0",
-    "react-dom": "^17.0.1",
+    "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
     "react-favicon": "^1.0.1",
     "react-helmet": "^6.1.0",
     "react-hook-form": "7.29.0",
     "react-hot-toast": "^2.4.0",
     "react-i18next": "^11.16.6",
-    "react-loading-skeleton": "^3.1.0",
+    "react-loading-skeleton": "3.0.0",
     "react-minimal-pie-chart": "^8.4.0",
     "react-paginate": "^8.1.4",
     "react-query": "^3.34.19",
@@ -59,7 +60,7 @@
     "@types/dateformat": "^5.0.0",
     "@types/node": "^17.0.23",
     "@types/react": "^17.0.43",
-    "@types/react-dom": "^17.0.14",
+    "@types/react-dom": "^18.2.0",
     "@types/react-helmet": "^6.1.5",
     "typescript": "^4.6.3"
   }


### PR DESCRIPTION
Part of: https://conduction.atlassian.net/browse/NDT-28.

It does require `npm i --legacy-peer-deps`, but I think we already had to do that. Everything should work with the new package though! 🚀 