### PR TITLE
ADD .xls and .ods support

### DIFF
--- a/pwa/src/templates/templateParts/importResourceActions/formSteps/fileSelect/FormStepFileSelect.tsx
+++ b/pwa/src/templates/templateParts/importResourceActions/formSteps/fileSelect/FormStepFileSelect.tsx
@@ -29,6 +29,8 @@ export const FormStepFileSelect: React.FC<FormStepFileSelect> = ({ setValue, reg
     onDrop,
     accept: {
       "application/xlsx": [".xlsx"],
+      "application/xls": [".xls"],
+      "application/ods": [".ods"],
     },
   });
 
@@ -39,7 +41,7 @@ export const FormStepFileSelect: React.FC<FormStepFileSelect> = ({ setValue, reg
 
         <FontAwesomeIcon className={styles.icon} icon={faFileImport} />
 
-        <span>Drag your file (.xlsx) here to start uploading.</span>
+        <span>Drag your file (.xlsx, .xls, or .ods) here to start uploading.</span>
 
         <span className={styles.otherOptionIndicator}>— or —</span>
 


### PR DESCRIPTION
This pull request adds .xls and .ods support to the import page. 

Testing can be done on this live gateway: https://api.gateway.commonground.nu. 

Schema used: b9682ec5-14b1-4669-a52a-2519247502f5
Mapping used: 34b92ae8-a180-4e8c-b0d5-e95404a96b4e

(I've never received a .xls file, but adding any .xls file will create the correct errors, which means the upload is working fine)

[Top2000 Stemlijst 202.ods](https://github.com/ConductionNL/gateway-ui/files/12513987/Top2000.Stemlijst.202.ods)
