### PR TITLE
ADD Utrecht button tokens and styling

### DIFF
--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -8,7 +8,7 @@
       "name": "skeleton-app",
       "version": "1.0.0",
       "dependencies": {
-        "@conduction/components": "2.2.0",
+        "@conduction/components": "2.2.2",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
@@ -1865,20 +1865,13 @@
       }
     },
     "node_modules/@conduction/components": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@conduction/components/-/components-2.2.0.tgz",
-      "integrity": "sha512-bAJHU3fn+e3lH2kZXAfHJOhdITVbV8tyqIBU72YRiANe+azVNnVjJ2fIrEDCW0oV6Fo6lZ4g7otvdzTHy7JBeg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@conduction/components/-/components-2.2.2.tgz",
+      "integrity": "sha512-otmLdj8CtbSlgrA2divxwdquxZP1nNj3mwl3uXF8LCtiQi3sjJTSazHFka3twKTMyLU4D5l/vcG+QUr8+cMbdQ==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
         "@fortawesome/free-solid-svg-icons": "^6.2.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
-        "@gemeente-denhaag/button": "0.2.3-alpha.205",
-        "@gemeente-denhaag/form-field": "0.1.1-alpha.98",
-        "@gemeente-denhaag/icons": "^0.2.3-alpha.317",
-        "@gemeente-denhaag/process-steps": "0.1.0-alpha.51",
-        "@gemeente-denhaag/sidenav": "0.1.0-alpha.40",
-        "@gemeente-denhaag/textarea": "0.1.1-alpha.95",
-        "@gemeente-denhaag/textfield": "0.2.3-alpha.205",
         "@utrecht/component-library-react": "^1.0.0-alpha.319",
         "clsx": "^1.1.1",
         "gatsby": "^4.11.1",
@@ -1899,52 +1892,6 @@
       "peerDependencies": {
         "@fortawesome/fontawesome-svg-core": "~1 || ~6",
         "react": ">=16.3"
-      }
-    },
-    "node_modules/@conduction/components/node_modules/@gemeente-denhaag/baseprops": {
-      "version": "0.2.3-alpha.205",
-      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/baseprops/-/baseprops-0.2.3-alpha.205.tgz",
-      "integrity": "sha512-RZGOwSEpYJlrNFNppP6Ztl/44ld1HxnVk931D02G1+55qiQFh/ZGu+p7cH4eDO9tEtHuITIH3F5sQnhAG0hWiw==",
-      "peerDependencies": {
-        "react": "^17.0.0"
-      }
-    },
-    "node_modules/@conduction/components/node_modules/@gemeente-denhaag/button": {
-      "version": "0.2.3-alpha.205",
-      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/button/-/button-0.2.3-alpha.205.tgz",
-      "integrity": "sha512-I7RX236hCFjOQHoPC879385ACHoF2mzh8+z9sgznozZ+PwYzkMAWO7IZqd3rJooIMQNubJDCfXGHm8Y6lVXGsw==",
-      "dependencies": {
-        "@gemeente-denhaag/baseprops": "0.2.3-alpha.205"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0"
-      }
-    },
-    "node_modules/@conduction/components/node_modules/@gemeente-denhaag/icons": {
-      "version": "0.2.3-alpha.324",
-      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/icons/-/icons-0.2.3-alpha.324.tgz",
-      "integrity": "sha512-sVPDFFbgqEPw4e9k5fkjQCVBakyMNq2aJs2nuauRQfLxz5HrwnJN9wieG+4l/NAeUxSURMSDoDsNaJf6bODEpA==",
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@conduction/components/node_modules/@gemeente-denhaag/textfield": {
-      "version": "0.2.3-alpha.205",
-      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/textfield/-/textfield-0.2.3-alpha.205.tgz",
-      "integrity": "sha512-zG1fYxAQ1hOVTbcyVMaPZRjFGsPcNhoRfOigXZcvmnnzXQLKQsUgV69nHDc/0VyaqSCv09wXB9DLUKJLg0XjAA==",
-      "dependencies": {
-        "@gemeente-denhaag/icons": "0.2.3-alpha.205"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0"
-      }
-    },
-    "node_modules/@conduction/components/node_modules/@gemeente-denhaag/textfield/node_modules/@gemeente-denhaag/icons": {
-      "version": "0.2.3-alpha.205",
-      "resolved": "https://registry.npmjs.org/@gemeente-denhaag/icons/-/icons-0.2.3-alpha.205.tgz",
-      "integrity": "sha512-SQpiE7iuIpD3zvOZ48mY+skb7RaIr0TkeSoxIz3X5lTr+VjQf7OFKpFTECSnPrpphOQ4CQ6hSAtM/CwnEzWzXQ==",
-      "peerDependencies": {
-        "react": "^17.0.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -16629,20 +16576,13 @@
       "version": "0.5.4"
     },
     "@conduction/components": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@conduction/components/-/components-2.2.0.tgz",
-      "integrity": "sha512-bAJHU3fn+e3lH2kZXAfHJOhdITVbV8tyqIBU72YRiANe+azVNnVjJ2fIrEDCW0oV6Fo6lZ4g7otvdzTHy7JBeg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@conduction/components/-/components-2.2.2.tgz",
+      "integrity": "sha512-otmLdj8CtbSlgrA2divxwdquxZP1nNj3mwl3uXF8LCtiQi3sjJTSazHFka3twKTMyLU4D5l/vcG+QUr8+cMbdQ==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
         "@fortawesome/free-solid-svg-icons": "^6.2.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
-        "@gemeente-denhaag/button": "0.2.3-alpha.205",
-        "@gemeente-denhaag/form-field": "0.1.1-alpha.98",
-        "@gemeente-denhaag/icons": "^0.2.3-alpha.317",
-        "@gemeente-denhaag/process-steps": "0.1.0-alpha.51",
-        "@gemeente-denhaag/sidenav": "0.1.0-alpha.40",
-        "@gemeente-denhaag/textarea": "0.1.1-alpha.95",
-        "@gemeente-denhaag/textfield": "0.2.3-alpha.205",
         "@utrecht/component-library-react": "^1.0.0-alpha.319",
         "clsx": "^1.1.1",
         "gatsby": "^4.11.1",
@@ -16658,39 +16598,6 @@
           "version": "0.2.0",
           "requires": {
             "prop-types": "^15.8.1"
-          }
-        },
-        "@gemeente-denhaag/baseprops": {
-          "version": "0.2.3-alpha.205",
-          "resolved": "https://registry.npmjs.org/@gemeente-denhaag/baseprops/-/baseprops-0.2.3-alpha.205.tgz",
-          "integrity": "sha512-RZGOwSEpYJlrNFNppP6Ztl/44ld1HxnVk931D02G1+55qiQFh/ZGu+p7cH4eDO9tEtHuITIH3F5sQnhAG0hWiw=="
-        },
-        "@gemeente-denhaag/button": {
-          "version": "0.2.3-alpha.205",
-          "resolved": "https://registry.npmjs.org/@gemeente-denhaag/button/-/button-0.2.3-alpha.205.tgz",
-          "integrity": "sha512-I7RX236hCFjOQHoPC879385ACHoF2mzh8+z9sgznozZ+PwYzkMAWO7IZqd3rJooIMQNubJDCfXGHm8Y6lVXGsw==",
-          "requires": {
-            "@gemeente-denhaag/baseprops": "0.2.3-alpha.205"
-          }
-        },
-        "@gemeente-denhaag/icons": {
-          "version": "0.2.3-alpha.324",
-          "resolved": "https://registry.npmjs.org/@gemeente-denhaag/icons/-/icons-0.2.3-alpha.324.tgz",
-          "integrity": "sha512-sVPDFFbgqEPw4e9k5fkjQCVBakyMNq2aJs2nuauRQfLxz5HrwnJN9wieG+4l/NAeUxSURMSDoDsNaJf6bODEpA=="
-        },
-        "@gemeente-denhaag/textfield": {
-          "version": "0.2.3-alpha.205",
-          "resolved": "https://registry.npmjs.org/@gemeente-denhaag/textfield/-/textfield-0.2.3-alpha.205.tgz",
-          "integrity": "sha512-zG1fYxAQ1hOVTbcyVMaPZRjFGsPcNhoRfOigXZcvmnnzXQLKQsUgV69nHDc/0VyaqSCv09wXB9DLUKJLg0XjAA==",
-          "requires": {
-            "@gemeente-denhaag/icons": "0.2.3-alpha.205"
-          },
-          "dependencies": {
-            "@gemeente-denhaag/icons": {
-              "version": "0.2.3-alpha.205",
-              "resolved": "https://registry.npmjs.org/@gemeente-denhaag/icons/-/icons-0.2.3-alpha.205.tgz",
-              "integrity": "sha512-SQpiE7iuIpD3zvOZ48mY+skb7RaIr0TkeSoxIz3X5lTr+VjQf7OFKpFTECSnPrpphOQ4CQ6hSAtM/CwnEzWzXQ=="
-            }
           }
         }
       }

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@conduction/components": "2.2.0",
+    "@conduction/components": "2.2.2",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",

--- a/pwa/src/styling/design-tokens/component-overrides.css
+++ b/pwa/src/styling/design-tokens/component-overrides.css
@@ -66,6 +66,95 @@
   --denhaag-checkbox-hover-checked-border-color: var(
     --gateway-ui-color-primary-hover
   );
+
+  --utrecht-button-background-color: var(--gateway-ui-color-primary);
+  --utrecht-button-border-width: var(--gateway-ui-size-3xs);
+
+  --utrecht-button-primary-action-background-color: var(
+    --gateway-ui-color-primary
+  );
+  --utrecht-button-primary-action-border-color: unset;
+  --utrecht-button-primary-action-border-width: var(--gateway-ui-size-3xs);
+  --utrecht-button-primary-action-color: var(--gateway-ui-color-white);
+  --utrecht-button-primary-action-active-background-color: var(
+    --gateway-ui-color-primary
+  );
+  --utrecht-button-primary-action-active-color: var(--gateway-ui-color-white);
+  --utrecht-button-primary-action-disabled-background-color: var(
+    --gateway-ui-color-disabled
+  );
+  --utrecht-button-primary-action-disabled-border-color: unset;
+  --utrecht-button-primary-action-disabled-color: var(--gateway-ui-color-black);
+  --utrecht-button-primary-action-hover-background-color: var(
+    --gateway-ui-color-primary-hover
+  );
+  --utrecht-button-primary-action-hover-border-color: unset;
+  --utrecht-button-primary-action-hover-color: var(--gateway-ui-color-white);
+  --utrecht-button-primary-action-focus-background-color: var(
+    --gateway-ui-color-primary-hover
+  );
+  --utrecht-button-primary-action-focus-border-color: unset;
+  --utrecht-button-primary-action-focus-color: var(--gateway-ui-color-white);
+  --utrecht-button-primary-action-pressed-background-color: var(
+    --gateway-ui-color-primary-hover
+  );
+  --utrecht-button-primary-action-pressed-border-color: unset;
+  --utrecht-button-primary-action-pressed-color: var(--gateway-ui-color-white);
+
+  --utrecht-button-secondary-action-background-color: var(
+    --gateway-ui-color-white
+  );
+  --utrecht-button-secondary-action-border-color: var(
+    --gateway-ui-color-primary
+  );
+  --utrecht-button-secondary-action-border-width: var(--gateway-ui-size-3xs);
+  --utrecht-button-secondary-action-color: var(--gateway-ui-color-primary);
+  --utrecht-button-secondary-action-font-weight: inherit;
+  --utrecht-button-secondary-action-active-background-color: var(
+    --gateway-ui-color-white
+  );
+  --utrecht-button-secondary-action-active-border-color: var(
+    --gateway-ui-color-primary
+  );
+  --utrecht-button-secondary-action-active-color: var(
+    --gateway-ui-color-primary
+  );
+  --utrecht-button-secondary-action-disabled-background-color: var(
+    --gateway-ui-color-white
+  );
+  --utrecht-button-secondary-action-disabled-border-color: var(
+    --gateway-ui-color-disabled
+  );
+  --utrecht-button-secondary-action-disabled-color: var(
+    --gateway-ui-color-black
+  );
+  --utrecht-button-secondary-action-hover-background-color: var(
+    --gateway-ui-color-white
+  );
+  --utrecht-button-secondary-action-hover-border-color: var(
+    --gateway-ui-color-primary-hover
+  );
+  --utrecht-button-secondary-action-hover-color: var(
+    --gateway-ui-color-primary-hover
+  );
+  --utrecht-button-secondary-action-focus-background-color: var(
+    --gateway-ui-color-white
+  );
+  --utrecht-button-secondary-action-focus-border-color: var(
+    --gateway-ui-color-primary-hover
+  );
+  --utrecht-button-secondary-action-focus-color: var(
+    --gateway-ui-color-primary-hover
+  );
+  --utrecht-button-secondary-action-pressed-background-color: var(
+    --gateway-ui-color-white
+  );
+  --utrecht-button-secondary-action-pressed-border-color: var(
+    --gateway-ui-color-primary-hover
+  );
+  --utrecht-button-secondary-action-pressed-color: var(
+    --gateway-uic-olor-primary-hover
+  );
 }
 
 .select-module--select--63d48 > div {

--- a/pwa/src/styling/global.css
+++ b/pwa/src/styling/global.css
@@ -3,3 +3,7 @@ body {
   margin: 0;
   --utrecht-document-background-color: #fafafa;
 }
+
+button:hover {
+  cursor: pointer;
+}


### PR DESCRIPTION
This pull request implements (some) Utrecht button styling. Because we're removing the Den Haag buttons from our conduction/components package: https://github.com/ConductionNL/conduction-components/pull/101.

These extra tokens and css rules are not meant to completely cover all button styling, only to not break the UI too much until the day we're implementing the actual JSON themes in the application.

Note: the Table in the CreateKeyValue component also breaks a bit, I've looked into it but we're implementing a Den Haag Table here, which itself has an dependency on the Utrecht tokens. Changing this would mean updating all Tables which is OOS for now.